### PR TITLE
Neighbouring states can now be further away than 1 stop

### DIFF
--- a/include/cltune/searchers/annealing.h
+++ b/include/cltune/searchers/annealing.h
@@ -44,6 +44,9 @@ class Annealing: public Searcher {
   // algorithm ends
   static constexpr auto kMaxAlreadyVisitedStates = 10;
 
+  // Maximum number of differences to consider this still a neighbour
+  static constexpr auto kMaxDifferences = 3;
+
   // Takes additionally a fraction of configurations to consider
   Annealing(const Configurations &configurations,
             const double fraction, const double max_temperature);

--- a/src/searchers/annealing.cc
+++ b/src/searchers/annealing.cc
@@ -134,8 +134,8 @@ std::vector<size_t> Annealing::GetNeighboursOf(const size_t reference_id) const 
       ++setting_id;
     }
 
-    // Consider this configuration a neighbour if there is exactly one difference
-    if (differences == 1) {
+    // Consider this configuration a neighbour if there is at most a certain amount of differences
+    if (differences == kMaxDifferences) {
       neighbours.push_back(other_id);
     }
     ++other_id;


### PR DESCRIPTION
Fix for simulated annealing when 2 variables can only change together.