### PR TITLE
Convolution 2D improvements

### DIFF
--- a/include/cltune/memory.h
+++ b/include/cltune/memory.h
@@ -52,9 +52,10 @@ class Memory {
   const static MemType type;
 
   // Initializes the host and device data (with zeroes or based on a source-vector)
-  explicit Memory(const size_t size, cl::CommandQueue queue, const cl::Context &context);
   explicit Memory(const size_t size, cl::CommandQueue queue, const cl::Context &context,
-                  const std::vector<T> &source);
+                  const cl_mem_flags flags);
+  explicit Memory(const size_t size, cl::CommandQueue queue, const cl::Context &context,
+                  const cl_mem_flags flags, const std::vector<T> &source);
 
   // Accessors to the host/device data
   std::vector<T> host() const { return host_; }

--- a/samples/conv.opencl
+++ b/samples/conv.opencl
@@ -309,8 +309,8 @@ __kernel void conv(const int goff, const int dummy,
   // Local memory
   const int lid_x = get_local_id(0); // From 0 to TBX
   const int lid_y = get_local_id(1); // From 0 to TBY
-  __local float lmem[(TBY*WPTY + 2*HFS) * (TBX*WPTX + 2*HFS)];
-  const int loff = TBX*WPTX + 2*HFS;
+  __local float lmem[(TBY*WPTY + 2*HFS) * (TBX*WPTX + 2*HFS + PADDING)];
+  const int loff = TBX*WPTX + 2*HFS + PADDING;
 
   // Caches data into local memory
   LoadLocalPlusHalo(lmem, loff, src, goff, gid_x, gid_y, lid_x, lid_y);
@@ -347,8 +347,8 @@ __kernel void conv(const int goff, const int dummy,
   // Local memory
   const int lid_x = get_local_id(0); // From 0 to (TBX + 2*HFS)
   const int lid_y = get_local_id(1); // From 0 to (TBY + 2*HFS)
-  __local float lmem[(TBY*WPTY + 2*HFS) * (TBX*WPTX + 2*HFS)];
-  const int loff = TBX*WPTX + 2*HFS;
+  __local float lmem[(TBY*WPTY + 2*HFS) * (TBX*WPTX + 2*HFS + PADDING)];
+  const int loff = TBX*WPTX + 2*HFS + PADDING;
 
   // Caches data into local memory
   LoadLocalFull(lmem, loff, src, goff, gid_x, gid_y, lid_x, lid_y);

--- a/samples/conv_reference.opencl
+++ b/samples/conv_reference.opencl
@@ -28,27 +28,16 @@
 //
 // =================================================================================================
 
-// Settings (also change these in conv.cc, conv.opencl, and conv_reference.opencl!!)
-#define HFS (3)        // Half filter size (synchronise with other files)
+// Settings (synchronise these with "conv.cc", "conv.opencl" and "conv_reference.opencl")
+#define HFS (3)        // Half filter size
 #define FS (HFS+HFS+1) // Filter size
-#define FA (FS*FS)     // Filter area
-
-// The filter values (max 7 x 7)
-__constant float coeff[FS][FS] = {
-  {1/98.0, 1/98.0, 1/98.0, 2/98.0, 1/98.0, 1/98.0, 1/98.0},
-  {1/98.0, 1/98.0, 1/98.0, 2/98.0, 1/98.0, 1/98.0, 1/98.0},
-  {1/98.0, 1/98.0, 2/98.0, 4/98.0, 2/98.0, 1/98.0, 1/98.0},
-  {2/98.0, 2/98.0, 4/98.0, 8/98.0, 4/98.0, 2/98.0, 2/98.0},
-  {1/98.0, 1/98.0, 2/98.0, 4/98.0, 2/98.0, 1/98.0, 1/98.0},
-  {1/98.0, 1/98.0, 1/98.0, 2/98.0, 1/98.0, 1/98.0, 1/98.0},
-  {1/98.0, 1/98.0, 1/98.0, 2/98.0, 1/98.0, 1/98.0, 1/98.0},
-};
 
 // =================================================================================================
 
 // Reference implementation of the 2D convolution example
 __kernel void conv_reference(const int size_x, const int size_y,
                              const __global float* src,
+                             __constant float* coeff,
                              __global float* dest) {
 
   // Thread identifiers
@@ -65,13 +54,13 @@ __kernel void conv_reference(const int size_x, const int size_y,
       const int index_y = tid_y + HFS + fy;
 
       // Performs the accumulation
-      float coefficient = coeff[fy+HFS][fx+HFS];
+      float coefficient = coeff[(fy+HFS)*FS + (fx+HFS)];
       acc += coefficient * src[index_y*size_x + index_x];
     }
   }
 
-  // Computes and stores the result
-  dest[tid_y*size_x + tid_x] = acc / (FS * FS);
+  // Stores the result
+  dest[tid_y*size_x + tid_x] = acc;
 }
 
 // =================================================================================================

--- a/src/memory.cc
+++ b/src/memory.cc
@@ -39,20 +39,21 @@ template <> const MemType Memory<double>::type = MemType::kDouble;
 // Initializes the memory class, creating a host array with zeroes and an uninitialized device
 // buffer.
 template <typename T>
-Memory<T>::Memory(const size_t size, cl::CommandQueue queue, const cl::Context &context):
+Memory<T>::Memory(const size_t size, cl::CommandQueue queue, const cl::Context &context,
+                  const cl_mem_flags flags):
     size_(size),
     host_(size, static_cast<T>(0)),
-    device_(new cl::Buffer(context, CL_MEM_READ_WRITE, size*sizeof(T))),
+    device_(new cl::Buffer(context, flags, size*sizeof(T))),
     queue_(queue) {
 }
 
 // As above, but now initializes to a specific value based on a source vector.
 template <typename T>
 Memory<T>::Memory(const size_t size, cl::CommandQueue queue, const cl::Context &context,
-                  const std::vector<T> &source):
+                  const cl_mem_flags flags, const std::vector<T> &source):
     size_(size),
     host_(source),
-    device_(new cl::Buffer(context, CL_MEM_READ_WRITE, size*sizeof(T))),
+    device_(new cl::Buffer(context, flags, size*sizeof(T))),
     queue_(queue) {
 }
 

--- a/src/tuner.cc
+++ b/src/tuner.cc
@@ -183,7 +183,8 @@ void Tuner::SetLocalMemoryUsage(const size_t id, KernelInfo::LocalMemoryFunction
 // vector of data. Then, upload it to the device and store the argument in a list.
 template <typename T>
 void Tuner::AddArgumentInput(const std::vector<T> &source) {
-  auto buffer = Memory<T>{source.size(), opencl_->queue(), opencl_->context(), source};
+  auto buffer = Memory<T>{source.size(), opencl_->queue(), opencl_->context(), CL_MEM_READ_ONLY,
+                          source};
   buffer.UploadToDevice();
   MemArgument argument = {argument_counter_++, source.size(), buffer.type, *buffer.device()};
   arguments_input_.push_back(argument);
@@ -195,7 +196,8 @@ template void Tuner::AddArgumentInput<double>(const std::vector<double>&);
 // As above, but now marked as output buffer
 template <typename T>
 void Tuner::AddArgumentOutput(const std::vector<T> &source) {
-  auto buffer = Memory<T>{source.size(), opencl_->queue(), opencl_->context(), source};
+  auto buffer = Memory<T>{source.size(), opencl_->queue(), opencl_->context(), CL_MEM_READ_WRITE,
+                          source};
   MemArgument argument = {argument_counter_++, source.size(), buffer.type, *buffer.device()};
   arguments_output_.push_back(argument);
 }


### PR DESCRIPTION
Improved the convolution 2D example:
- Filter coefficients are now dynamic and loaded from memory (slower, but more realistic)
- OpenCL input buffers are now read-only
- Fixed a bug with halo threads when LOCAL=2 and the work-per-thread is larger than 1
- Made caching from global or local memory into registers explicit (no performance impact)
- Added support for local memory padding