### PR TITLE
Added Travis continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,8 @@ before_script:
 script:
   - make
   - make install
+branches:
+  only:
+    - master
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: cpp
+compiler:
+  - gcc
+  - clang
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo add-apt-repository -y ppa:kalakris/cmake
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq gcc-4.8 g++-4.8 clang
+  - sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers
+  - sudo apt-get install -qq cmake
+install:
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+before_script:
+  - mkdir install
+  - export PATH=`pwd`/install/bin:${PATH}
+  - export LD_LIBRARY_PATH=`pwd`/install/lib64:`pwd`/install/lib:${LD_LIBRARY_PATH}
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_INSTALL_PREFIX:PATH=../install -DSAMPLES=ON -DTESTS=ON ..
+script:
+  - make
+  - make install
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 CLTune: Automatic OpenCL kernel tuning
 ================
 
+[![Build Status](https://travis-ci.org/CNugteren/cltune.svg?branch=master)](https://travis-ci.org/CNugteren/cltune)
+
 CLTune is a C++ library which can be used to automatically tune your OpenCL kernels. The only thing you'll need to provide is a tuneable kernel and a list of allowed parameters and values.
 
 For example, if you would perform loop unrolling or local memory tiling through a pre-processor define, just remove the define from your kernel code, pass the kernel to CLTune and tell it what the name of your parameter(s) are and what values you want to try. CLTune will take care of the rest: it will iterate over all possible permutations, test them, and report the best combination.


### PR DESCRIPTION
Added an initial .travis.yml file to add automatic build testing using Travis CI. For now this tests only the compilation itself (using GCC 4.8 and Clang 3.4).