### PR TITLE
Machine learning models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,9 @@ set(TUNER
     src/searchers/full_search.cc
     src/searchers/random_search.cc
     src/searchers/annealing.cc
-    src/searchers/pso.cc)
+    src/searchers/pso.cc
+    src/ml_model.cc
+    src/ml_models/linear_regression.cc)
 
 # Creates and links the library
 add_library(cltune SHARED ${TUNER})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,8 @@ set(TUNER
     src/searchers/annealing.cc
     src/searchers/pso.cc
     src/ml_model.cc
-    src/ml_models/linear_regression.cc)
+    src/ml_models/linear_regression.cc
+    src/ml_models/neural_network.cc)
 
 # Creates and links the library
 add_library(cltune SHARED ${TUNER})

--- a/include/cltune.h
+++ b/include/cltune.h
@@ -50,6 +50,9 @@ using LocalMemoryFunction = std::function<size_t(std::vector<size_t>)>;
 // Enumeration for search strategies
 enum class SearchMethod{FullSearch, RandomSearch, Annealing, PSO};
 
+// Machine learning models
+enum class Model { kLinearRegression };
+
 // The tuner class and its public API
 class Tuner {
  public:
@@ -122,6 +125,11 @@ class Tuner {
   // Starts the tuning process: compile all kernels and run them for each permutation of the tuning-
   // parameters. Note that this might take a while.
   void Tune();
+
+  // Trains a machine learning model based on the search space explored so far. Then, all the
+  // missing data-points are estimated based on this model. This is only useful if a fraction of
+  // the search space is explored, as is the case when doing random-search.
+  void ModelPrediction(const Model model);
 
   // Prints the results of the tuning either to screen (stdout) or to a specific output-file.
   // Returns the execution time in miliseconds.

--- a/include/cltune.h
+++ b/include/cltune.h
@@ -51,7 +51,7 @@ using LocalMemoryFunction = std::function<size_t(std::vector<size_t>)>;
 enum class SearchMethod{FullSearch, RandomSearch, Annealing, PSO};
 
 // Machine learning models
-enum class Model { kLinearRegression };
+enum class Model { kLinearRegression, kNeuralNetwork };
 
 // The tuner class and its public API
 class Tuner {

--- a/include/cltune.h
+++ b/include/cltune.h
@@ -129,7 +129,8 @@ class Tuner {
   // Trains a machine learning model based on the search space explored so far. Then, all the
   // missing data-points are estimated based on this model. This is only useful if a fraction of
   // the search space is explored, as is the case when doing random-search.
-  void ModelPrediction(const Model model);
+  void ModelPrediction(const Model model_type, const float validation_fraction,
+                       const size_t test_top_x_configurations);
 
   // Prints the results of the tuning either to screen (stdout) or to a specific output-file.
   // Returns the execution time in miliseconds.

--- a/include/internal/clpp11.h
+++ b/include/internal/clpp11.h
@@ -147,7 +147,7 @@ class Device {
     auto num_devices = platform.NumDevices();
     if (num_devices == 0) { Error("no devices found"); }
     auto devices = std::vector<cl_device_id>(num_devices);
-    CheckError(clGetDeviceIDs(platform(), CL_DEVICE_TYPE_ALL, num_devices, devices.data(), nullptr));
+    CheckError(clGetDeviceIDs(platform(), CL_DEVICE_TYPE_ALL, static_cast<cl_uint>(num_devices), devices.data(), nullptr));
     if (device_id >= num_devices) { Error("invalid device ID "+std::to_string(device_id)); }
     device_ = devices[device_id];
   }

--- a/include/internal/ml_model.h
+++ b/include/internal/ml_model.h
@@ -59,11 +59,12 @@ class MLModel {
   // Process the training data
   void ComputeNormalizations(const std::vector<std::vector<T>> &x);
   void NormalizeFeatures(std::vector<std::vector<T>> &x);
-  void AddPolynominalFeatures(std::vector<std::vector<T>> &x, const size_t order);
+  void AddPolynomialFeatures(std::vector<std::vector<T>> &x, const std::vector<size_t> &orders);
+  void AddPolynomialRecursive(std::vector<T> &xi, const size_t order, const T value, const size_t n);
 
   // Methods to minimize an unconstrained function
   void GradientDescent(const std::vector<std::vector<T>> &x, const std::vector<T> &y,
-                       const T alpha, const size_t iterations);
+                       const T alpha, const T lambda, const size_t iterations);
 
   // Verification methods
   float Verify(const std::vector<std::vector<T>> &x, const std::vector<T> &y,
@@ -71,9 +72,9 @@ class MLModel {
 
   // Pure virtual hypothesis, cost and gradient functions
   virtual T Hypothesis(const std::vector<T> &x) const = 0;
-  virtual T Cost(const size_t m, const size_t n,
+  virtual T Cost(const size_t m, const size_t n, const T lambda,
                  const std::vector<std::vector<T>> &x, const std::vector<T> &y) const = 0;
-  virtual T Gradient(const size_t m, const size_t n,
+  virtual T Gradient(const size_t m, const size_t n, const T lambda,
                      const std::vector<std::vector<T>> &x, const std::vector<T> &y,
                      const size_t gradient_id) const = 0;
 

--- a/include/internal/ml_model.h
+++ b/include/internal/ml_model.h
@@ -67,8 +67,9 @@ class MLModel {
                        const T alpha, const T lambda, const size_t iterations);
 
   // Verification methods
-  float Verify(const std::vector<std::vector<T>> &x, const std::vector<T> &y,
-               const float margin) const;
+  float SuccessRate(const std::vector<std::vector<T>> &x, const std::vector<T> &y,
+                    const float margin) const;
+  float Verify(const std::vector<std::vector<T>> &x, const std::vector<T> &y) const;
 
   // Pure virtual hypothesis, cost and gradient functions
   virtual T Hypothesis(const std::vector<T> &x) const = 0;

--- a/include/internal/ml_model.h
+++ b/include/internal/ml_model.h
@@ -49,19 +49,22 @@ class MLModel {
   static constexpr auto kGradientDescentCostReportAmount = 10;
 
   // Constructor
-  MLModel();
+  MLModel(const bool debug_display);
 
   // Trains and validates the model
   virtual void Train(const std::vector<std::vector<T>> &x, const std::vector<T> &y) = 0;
   virtual void Validate(const std::vector<std::vector<T>> &x, const std::vector<T> &y) = 0;
 
- protected:
+  // Pure virtual prediction function: predicts 'y' based on 'x' and the learning parameters 'theta'
+  virtual T Predict(const std::vector<T> &x) const = 0;
 
+ protected:
   // Process the training data in various ways
   void ComputeNormalizations(const std::vector<std::vector<T>> &x);
-  void NormalizeFeatures(std::vector<std::vector<T>> &x);
-  void AddPolynomialFeatures(std::vector<std::vector<T>> &x, const std::vector<size_t> &orders);
-  void AddPolynomialRecursive(std::vector<T> &xi, const size_t order, const T value, const size_t n);
+  void NormalizeFeatures(std::vector<std::vector<T>> &x) const;
+  void AddPolynomialFeatures(std::vector<std::vector<T>> &x, const std::vector<size_t> &orders) const;
+  void AddPolynomialRecursive(std::vector<T> &xi, const size_t order, const T value,
+                              const size_t n) const;
 
   // Methods to minimize an unconstrained function
   void GradientDescent(const std::vector<std::vector<T>> &x, const std::vector<T> &y,
@@ -71,6 +74,12 @@ class MLModel {
   float SuccessRate(const std::vector<std::vector<T>> &x, const std::vector<T> &y,
                     const float margin) const;
   float Verify(const std::vector<std::vector<T>> &x, const std::vector<T> &y) const;
+
+  // Pre and post-processing of data
+  virtual T PostProcessExecutionTime(T value) const = 0;
+
+  // Pure virtual function for weights initialization
+  virtual void InitializeTheta() = 0;
 
   // Pure virtual hypothesis, cost and gradient functions: to be implemented by derived classes
   virtual T Hypothesis(const std::vector<T> &x) const = 0;
@@ -86,6 +95,9 @@ class MLModel {
   // Information for normalization
   std::vector<T> ranges_;
   std::vector<T> means_;
+
+  // Settings
+  const bool debug_display_;
 };
 
 // =================================================================================================

--- a/include/internal/ml_model.h
+++ b/include/internal/ml_model.h
@@ -6,7 +6,8 @@
 // Author: cedric.nugteren@surfsara.nl (Cedric Nugteren)
 //
 // This file contains a base class which implements machine learning models. Actual models are
-// derived from this class, such as linear regression or a neural network.
+// derived from this class, such as linear regression or a neural network. This class contains
+// common functionality, such as gradient descent and feature normalization.
 //
 // -------------------------------------------------------------------------------------------------
 //
@@ -48,7 +49,7 @@ class MLModel {
   static constexpr auto kGradientDescentCostReportAmount = 10;
 
   // Constructor
-  MLModel(const size_t m, const size_t n);
+  MLModel();
 
   // Trains and validates the model
   virtual void Train(const std::vector<std::vector<T>> &x, const std::vector<T> &y) = 0;
@@ -56,7 +57,7 @@ class MLModel {
 
  protected:
 
-  // Process the training data
+  // Process the training data in various ways
   void ComputeNormalizations(const std::vector<std::vector<T>> &x);
   void NormalizeFeatures(std::vector<std::vector<T>> &x);
   void AddPolynomialFeatures(std::vector<std::vector<T>> &x, const std::vector<size_t> &orders);
@@ -71,7 +72,7 @@ class MLModel {
                     const float margin) const;
   float Verify(const std::vector<std::vector<T>> &x, const std::vector<T> &y) const;
 
-  // Pure virtual hypothesis, cost and gradient functions
+  // Pure virtual hypothesis, cost and gradient functions: to be implemented by derived classes
   virtual T Hypothesis(const std::vector<T> &x) const = 0;
   virtual T Cost(const size_t m, const size_t n, const T lambda,
                  const std::vector<std::vector<T>> &x, const std::vector<T> &y) const = 0;

--- a/include/internal/ml_model.h
+++ b/include/internal/ml_model.h
@@ -79,18 +79,14 @@ class MLModel {
   virtual T PostProcessExecutionTime(T value) const = 0;
 
   // Pure virtual function for weights initialization
-  virtual void InitializeTheta() = 0;
+  virtual void InitializeTheta(const size_t n) = 0;
 
   // Pure virtual hypothesis, cost and gradient functions: to be implemented by derived classes
   virtual T Hypothesis(const std::vector<T> &x) const = 0;
   virtual T Cost(const size_t m, const size_t n, const T lambda,
                  const std::vector<std::vector<T>> &x, const std::vector<T> &y) const = 0;
-  virtual T Gradient(const size_t m, const size_t n, const T lambda,
-                     const std::vector<std::vector<T>> &x, const std::vector<T> &y,
-                     const size_t gradient_id) const = 0;
-
-  // The learned weights
-  std::vector<T> theta_;
+  virtual void Gradient(const size_t m, const size_t n, const T lambda, const T alpha,
+                        const std::vector<std::vector<T>> &x, const std::vector<T> &y) = 0;
 
   // Information for normalization
   std::vector<T> ranges_;

--- a/include/internal/ml_model.h
+++ b/include/internal/ml_model.h
@@ -1,0 +1,92 @@
+
+// =================================================================================================
+// This file is part of the CLTune project, which loosely follows the Google C++ styleguide and uses
+// a tab-size of two spaces and a max-width of 100 characters per line.
+//
+// Author: cedric.nugteren@surfsara.nl (Cedric Nugteren)
+//
+// This file contains a base class which implements machine learning models. Actual models are
+// derived from this class, such as linear regression or a neural network.
+//
+// -------------------------------------------------------------------------------------------------
+//
+// Copyright 2014 SURFsara
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//  http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// =================================================================================================
+
+#ifndef CLTUNE_ML_MODEL_H_
+#define CLTUNE_ML_MODEL_H_
+
+#include <vector>
+#include <string>
+#include <functional>
+
+// For output formatting messages
+#include "internal/tuner_impl.h"
+
+namespace cltune {
+// =================================================================================================
+
+// See comment at top of file for a description of the class
+template <typename T>
+class MLModel {
+ public:
+
+  // Constants
+  static constexpr auto kGradientDescentCostReportAmount = 10;
+
+  // Constructor
+  MLModel(const size_t m, const size_t n);
+
+  // Trains and validates the model
+  virtual void Train(const std::vector<std::vector<T>> &x, const std::vector<T> &y) = 0;
+  virtual void Validate(const std::vector<std::vector<T>> &x, const std::vector<T> &y) = 0;
+
+ protected:
+
+  // Process the training data
+  void ComputeNormalizations(const std::vector<std::vector<T>> &x);
+  void NormalizeFeatures(std::vector<std::vector<T>> &x);
+  void AddPolynominalFeatures(std::vector<std::vector<T>> &x, const size_t order);
+
+  // Methods to minimize an unconstrained function
+  void GradientDescent(const std::vector<std::vector<T>> &x, const std::vector<T> &y,
+                       const T alpha, const size_t iterations);
+
+  // Verification methods
+  float Verify(const std::vector<std::vector<T>> &x, const std::vector<T> &y,
+               const float margin) const;
+
+  // Pure virtual hypothesis, cost and gradient functions
+  virtual T Hypothesis(const std::vector<T> &x) const = 0;
+  virtual T Cost(const size_t m, const size_t n,
+                 const std::vector<std::vector<T>> &x, const std::vector<T> &y) const = 0;
+  virtual T Gradient(const size_t m, const size_t n,
+                     const std::vector<std::vector<T>> &x, const std::vector<T> &y,
+                     const size_t gradient_id) const = 0;
+
+  // The learned weights
+  std::vector<T> theta_;
+
+  // Information for normalization
+  std::vector<T> ranges_;
+  std::vector<T> means_;
+};
+
+// =================================================================================================
+} // namespace cltune
+
+// CLTUNE_ML_MODEL_H_
+#endif

--- a/include/internal/ml_models/linear_regression.h
+++ b/include/internal/ml_models/linear_regression.h
@@ -1,0 +1,79 @@
+
+// =================================================================================================
+// This file is part of the CLTune project, which loosely follows the Google C++ styleguide and uses
+// a tab-size of two spaces and a max-width of 100 characters per line.
+//
+// Author: cedric.nugteren@surfsara.nl (Cedric Nugteren)
+//
+// This file contains a linear regression model, derived from the base machine learning class.
+//
+// -------------------------------------------------------------------------------------------------
+//
+// Copyright 2014 SURFsara
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//  http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// =================================================================================================
+
+#ifndef CLTUNE_ML_MODELS_LINEAR_REGRESSION_H_
+#define CLTUNE_ML_MODELS_LINEAR_REGRESSION_H_
+
+#include <vector>
+
+// Machine learning base class
+#include "internal/ml_model.h"
+
+namespace cltune {
+// =================================================================================================
+
+// See comment at top of file for a description of the class
+template <typename T>
+class LinearRegression: public MLModel<T> {
+ public:
+
+  // Methods from the base class
+  using MLModel<T>::ComputeNormalizations;
+  using MLModel<T>::NormalizeFeatures;
+  using MLModel<T>::AddPolynominalFeatures;
+  using MLModel<T>::GradientDescent;
+  using MLModel<T>::Verify;
+
+  // Variables from the base class
+  using MLModel<T>::theta_;
+  using MLModel<T>::means_;
+  using MLModel<T>::ranges_;
+
+  // Constructor
+  LinearRegression(const size_t m, const size_t n);
+
+  // Trains and validates the model
+  virtual void Train(const std::vector<std::vector<T>> &x, const std::vector<T> &y) override;
+  virtual void Validate(const std::vector<std::vector<T>> &x, const std::vector<T> &y) override;
+
+ private:
+
+  // Hypothesis, cost and gradient functions
+  virtual T Hypothesis(const std::vector<T> &x) const override;
+  virtual T Cost(const size_t m, const size_t n,
+                 const std::vector<std::vector<T>> &x, const std::vector<T> &y) const override;
+  virtual T Gradient(const size_t m, const size_t n,
+                     const std::vector<std::vector<T>> &x, const std::vector<T> &y,
+                     const size_t gradient_id) const override;
+
+};
+
+// =================================================================================================
+} // namespace cltune
+
+// CLTUNE_ML_MODELS_LINEAR_REGRESSION_H_
+#endif

--- a/include/internal/ml_models/linear_regression.h
+++ b/include/internal/ml_models/linear_regression.h
@@ -54,7 +54,7 @@ class LinearRegression: public MLModel<T> {
   using MLModel<T>::ranges_;
 
   // Constructor
-  LinearRegression(const size_t m, const size_t n);
+  LinearRegression();
 
   // Trains and validates the model
   virtual void Train(const std::vector<std::vector<T>> &x, const std::vector<T> &y) override;

--- a/include/internal/ml_models/linear_regression.h
+++ b/include/internal/ml_models/linear_regression.h
@@ -44,7 +44,7 @@ class LinearRegression: public MLModel<T> {
   // Methods from the base class
   using MLModel<T>::ComputeNormalizations;
   using MLModel<T>::NormalizeFeatures;
-  using MLModel<T>::AddPolynominalFeatures;
+  using MLModel<T>::AddPolynomialFeatures;
   using MLModel<T>::GradientDescent;
   using MLModel<T>::Verify;
 
@@ -62,11 +62,14 @@ class LinearRegression: public MLModel<T> {
 
  private:
 
+  // Class-specific helper functions
+  void PreProcessFeatures(std::vector<std::vector<T>> &x);
+
   // Hypothesis, cost and gradient functions
   virtual T Hypothesis(const std::vector<T> &x) const override;
-  virtual T Cost(const size_t m, const size_t n,
+  virtual T Cost(const size_t m, const size_t n, const T lambda,
                  const std::vector<std::vector<T>> &x, const std::vector<T> &y) const override;
-  virtual T Gradient(const size_t m, const size_t n,
+  virtual T Gradient(const size_t m, const size_t n, const T lambda,
                      const std::vector<std::vector<T>> &x, const std::vector<T> &y,
                      const size_t gradient_id) const override;
 

--- a/include/internal/ml_models/linear_regression.h
+++ b/include/internal/ml_models/linear_regression.h
@@ -49,7 +49,6 @@ class LinearRegression: public MLModel<T> {
   using MLModel<T>::Verify;
 
   // Variables from the base class
-  using MLModel<T>::theta_;
   using MLModel<T>::means_;
   using MLModel<T>::ranges_;
 
@@ -71,16 +70,19 @@ class LinearRegression: public MLModel<T> {
   virtual T PostProcessExecutionTime(T value) const override;
 
   // Initializes the weights
-  virtual void InitializeTheta() override;
+  virtual void InitializeTheta(const size_t n) override;
 
   // Hypothesis, cost and gradient functions
   virtual T Hypothesis(const std::vector<T> &x) const override;
   virtual T Cost(const size_t m, const size_t n, const T lambda,
                  const std::vector<std::vector<T>> &x, const std::vector<T> &y) const override;
-  virtual T Gradient(const size_t m, const size_t n, const T lambda,
-                     const std::vector<std::vector<T>> &x, const std::vector<T> &y,
-                     const size_t gradient_id) const override;
+  virtual void Gradient(const size_t m, const size_t n, const T lambda, const T alpha,
+                        const std::vector<std::vector<T>> &x, const std::vector<T> &y) override;
 
+  // The learned weights
+  std::vector<T> theta_;
+
+  // Settings
   size_t learning_iterations_;
   T learning_rate_;
   T lambda_; // Regularization parameter

--- a/include/internal/ml_models/linear_regression.h
+++ b/include/internal/ml_models/linear_regression.h
@@ -54,16 +54,24 @@ class LinearRegression: public MLModel<T> {
   using MLModel<T>::ranges_;
 
   // Constructor
-  LinearRegression();
+  LinearRegression(const size_t learning_iterations, const T learning_rate, const T lambda,
+                   const bool debug_display);
 
   // Trains and validates the model
   virtual void Train(const std::vector<std::vector<T>> &x, const std::vector<T> &y) override;
   virtual void Validate(const std::vector<std::vector<T>> &x, const std::vector<T> &y) override;
 
- private:
+  // Prediction
+  virtual T Predict(const std::vector<T> &x) const override;
 
-  // Class-specific helper functions
-  void PreProcessFeatures(std::vector<std::vector<T>> &x);
+ private:
+  // Pre and post-processing of data
+  void PreProcessFeatures(std::vector<std::vector<T>> &x) const;
+  void PreProcessExecutionTimes(std::vector<T> &y) const;
+  virtual T PostProcessExecutionTime(T value) const override;
+
+  // Initializes the weights
+  virtual void InitializeTheta() override;
 
   // Hypothesis, cost and gradient functions
   virtual T Hypothesis(const std::vector<T> &x) const override;
@@ -73,6 +81,9 @@ class LinearRegression: public MLModel<T> {
                      const std::vector<std::vector<T>> &x, const std::vector<T> &y,
                      const size_t gradient_id) const override;
 
+  size_t learning_iterations_;
+  T learning_rate_;
+  T lambda_; // Regularization parameter
 };
 
 // =================================================================================================

--- a/include/internal/ml_models/neural_network.h
+++ b/include/internal/ml_models/neural_network.h
@@ -1,0 +1,113 @@
+
+// =================================================================================================
+// This file is part of the CLTune project, which loosely follows the Google C++ styleguide and uses
+// a tab-size of two spaces and a max-width of 100 characters per line.
+//
+// Author: cedric.nugteren@surfsara.nl (Cedric Nugteren)
+//
+// This file contains a neural network model, derived from the base machine learning class.
+//
+// -------------------------------------------------------------------------------------------------
+//
+// Copyright 2014 SURFsara
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//  http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// =================================================================================================
+
+#ifndef CLTUNE_ML_MODELS_NEURAL_NETWORK_H_
+#define CLTUNE_ML_MODELS_NEURAL_NETWORK_H_
+
+#include <vector>
+
+// Machine learning base class
+#include "internal/ml_model.h"
+
+namespace cltune {
+// =================================================================================================
+
+// See comment at top of file for a description of the class
+template <typename T>
+class NeuralNetwork: public MLModel<T> {
+ public:
+
+  // Methods from the base class
+  using MLModel<T>::ComputeNormalizations;
+  using MLModel<T>::NormalizeFeatures;
+  using MLModel<T>::AddPolynomialFeatures;
+  using MLModel<T>::GradientDescent;
+  using MLModel<T>::Verify;
+
+  // Variables from the base class
+  using MLModel<T>::means_;
+  using MLModel<T>::ranges_;
+
+  // Constructor
+  NeuralNetwork(const size_t learning_iterations, const T learning_rate, const T lambda,
+                const std::vector<size_t> &layer_sizes, const bool debug_display);
+
+  // Trains and validates the model
+  virtual void Train(const std::vector<std::vector<T>> &x, const std::vector<T> &y) override;
+  virtual void Validate(const std::vector<std::vector<T>> &x, const std::vector<T> &y) override;
+
+  // Prediction
+  virtual T Predict(const std::vector<T> &x) const override;
+
+ private:
+  // Pre and post-processing of data
+  void PreProcessFeatures(std::vector<std::vector<T>> &x) const;
+  void PreProcessExecutionTimes(std::vector<T> &y) const;
+  virtual T PostProcessExecutionTime(T value) const override;
+
+  // Initializes the weights
+  virtual void InitializeTheta(const size_t n) override;
+
+  // Hypothesis, cost and gradient functions
+  virtual T Hypothesis(const std::vector<T> &x) const override;
+  virtual T Cost(const size_t m, const size_t n, const T lambda,
+                 const std::vector<std::vector<T>> &x, const std::vector<T> &y) const override;
+  virtual void Gradient(const size_t m, const size_t, const T lambda, const T alpha,
+                        const std::vector<std::vector<T>> &x, const std::vector<T> &y) override;
+
+  // Feed-forward helpers
+  std::vector<T> FeedForward0(const std::vector<T> &x) const;
+  std::vector<T> FeedForward1(const std::vector<T> &a0, const bool sigmoid) const;
+  std::vector<T> FeedForward2(const std::vector<T> &a1) const;
+
+  // Helpers for the sigmoid function
+  T Sigmoid(const T value) const {
+    return static_cast<T>(1) / (static_cast<T>(1) + static_cast<T>(exp(-value)));
+  }
+  T SigmoidGradient(const T value) const {
+    return Sigmoid(value)*(static_cast<T>(1) - Sigmoid(value));
+  }
+
+  // The learned weights
+  std::vector<T> theta1_;
+  std::vector<T> theta2_;
+
+  // Neural network configuration
+  size_t num_layers_;
+  std::vector<size_t> layer_sizes_;
+
+  // Settings
+  size_t learning_iterations_;
+  T learning_rate_;
+  T lambda_; // Regularization parameter
+};
+
+// =================================================================================================
+} // namespace cltune
+
+// CLTUNE_ML_MODELS_NEURAL_NETWORK_H_
+#endif

--- a/include/internal/tuner_impl.h
+++ b/include/internal/tuner_impl.h
@@ -113,6 +113,9 @@ class TunerImpl {
   template <typename T> bool DownloadAndCompare(MemArgument &device_buffer, const size_t i);
   template <typename T> double AbsoluteDifference(const T reference, const T result);
 
+  // Trains and uses a machine learning model based on the search space explored so far
+  void ModelPrediction(const Model model);
+
   // Prints results of a particular kernel run
   void PrintResult(FILE* fp, const TunerResult &result, const std::string &message) const;
 

--- a/include/internal/tuner_impl.h
+++ b/include/internal/tuner_impl.h
@@ -114,7 +114,8 @@ class TunerImpl {
   template <typename T> double AbsoluteDifference(const T reference, const T result);
 
   // Trains and uses a machine learning model based on the search space explored so far
-  void ModelPrediction(const Model model);
+  void ModelPrediction(const Model model_type, const float validation_fraction,
+                       const size_t test_top_x_configurations);
 
   // Prints results of a particular kernel run
   void PrintResult(FILE* fp, const TunerResult &result, const std::string &message) const;

--- a/samples/conv/conv.cc
+++ b/samples/conv/conv.cc
@@ -208,7 +208,7 @@ int main(int argc, char* argv[]) {
   if (method == 0) {
     auto validation_fraction = 0.20f; // 20%
     auto top_x = 10UL; // Tests the top-10 best found results from the model on actual hardware
-    tuner.ModelPrediction(cltune::Model::kLinearRegression, validation_fraction, top_x);
+    tuner.ModelPrediction(cltune::Model::kNeuralNetwork, validation_fraction, top_x);
   }
 
   // Prints the results to screen and to file

--- a/samples/conv/conv.cc
+++ b/samples/conv/conv.cc
@@ -115,7 +115,7 @@ int main(int argc, char* argv[]) {
   // 1) Simulated annealing
   // 2) Particle swarm optimisation (PSO)
   // 3) Full search
-  auto fraction = 1/128.0f;
+  auto fraction = 1/64.0f;
   if      (method == 0) { tuner.UseRandomSearch(fraction); }
   else if (method == 1) { tuner.UseAnnealing(fraction, static_cast<size_t>(search_param_1)); }
   else if (method == 2) { tuner.UsePSO(fraction, static_cast<size_t>(search_param_1), 0.4, 0.0, 0.4); }
@@ -201,6 +201,13 @@ int main(int argc, char* argv[]) {
 
   // Starts the tuner
   tuner.Tune();
+
+  // The search method only explored a random subset of the whole search space. The collected data
+  // is used to train a model which is then used to estimate all the other (not-explored) points in
+  // the search space.
+  if (method == 0) {
+    tuner.ModelPrediction(cltune::Model::kLinearRegression);
+  }
 
   // Prints the results to screen and to file
   auto time_ms = tuner.PrintToScreen();

--- a/samples/conv/conv.cc
+++ b/samples/conv/conv.cc
@@ -206,7 +206,9 @@ int main(int argc, char* argv[]) {
   // is used to train a model which is then used to estimate all the other (not-explored) points in
   // the search space.
   if (method == 0) {
-    tuner.ModelPrediction(cltune::Model::kLinearRegression);
+    auto validation_fraction = 0.20f; // 20%
+    auto top_x = 10UL; // Tests the top-10 best found results from the model on actual hardware
+    tuner.ModelPrediction(cltune::Model::kLinearRegression, validation_fraction, top_x);
   }
 
   // Prints the results to screen and to file

--- a/src/cltune.cc
+++ b/src/cltune.cc
@@ -265,8 +265,9 @@ void Tuner::Tune() {
 // =================================================================================================
 
 // Fits a machine learning model. See the TunerImpl's implemenation for details
-void Tuner::ModelPrediction(const Model model) {
-  pimpl->ModelPrediction(model);
+void Tuner::ModelPrediction(const Model model_type, const float validation_fraction,
+                            const size_t test_top_x_configurations) {
+  pimpl->ModelPrediction(model_type, validation_fraction, test_top_x_configurations);
 }
 
 // =================================================================================================

--- a/src/cltune.cc
+++ b/src/cltune.cc
@@ -264,6 +264,13 @@ void Tuner::Tune() {
 
 // =================================================================================================
 
+// Fits a machine learning model. See the TunerImpl's implemenation for details
+void Tuner::ModelPrediction(const Model model) {
+  pimpl->ModelPrediction(model);
+}
+
+// =================================================================================================
+
 // Iterates over all tuning results and prints each parameter configuration and the corresponding
 // timing-results. Printing is to stdout.
 double Tuner::PrintToScreen() const {

--- a/src/kernel_info.cc
+++ b/src/kernel_info.cc
@@ -41,7 +41,7 @@ KernelInfo::KernelInfo(const std::string name, const std::string source, const D
   parameters_(),
   configurations_(),
   constraints_(),
-  local_memory_(LocalMemory{[] (std::vector<size_t> v) { return size_t{0}; }, std::vector<std::string>(0)}),
+  local_memory_(LocalMemory{[] (std::vector<size_t>) { return size_t{0}; }, std::vector<std::string>(0)}),
   device_(device),
   global_base_(), local_base_(),
   global_(), local_(),

--- a/src/ml_model.cc
+++ b/src/ml_model.cc
@@ -121,12 +121,10 @@ void MLModel<T>::GradientDescent(const std::vector<std::vector<T>> &x, const std
   auto n = x[0].size();
 
   // Sets the initial theta values
-  theta_.resize(n);
-  InitializeTheta();
+  InitializeTheta(n);
 
   // Runs gradient descent
   for (auto iter=size_t{0}; iter<iterations; ++iter) {
-    auto theta_temp = std::vector<T>(n, static_cast<T>(0));
 
     // Computes the cost (to monitor convergence)
     auto cost = Cost(m, n, lambda, x, y);
@@ -136,15 +134,7 @@ void MLModel<T>::GradientDescent(const std::vector<std::vector<T>> &x, const std
     }
     
     // Computes the gradients and the updated parameters
-    for (auto nid=size_t{0}; nid<n; ++nid) {
-      auto gradient = Gradient(m, n, lambda, x, y, nid);
-      theta_temp[nid] = theta_[nid] - alpha * gradient;
-    }
-
-    // Sets the new values for theta
-    for (auto nid=size_t{0}; nid<n; ++nid) {
-      theta_[nid] = theta_temp[nid];
-    }
+    Gradient(m, n, lambda, alpha, x, y);
   }
 }
 

--- a/src/ml_model.cc
+++ b/src/ml_model.cc
@@ -76,7 +76,8 @@ template <typename T>
 void MLModel<T>::NormalizeFeatures(std::vector<std::vector<T>> &x) const {
   for (auto mid=size_t{0}; mid<x.size(); ++mid) {
     for (auto nid=size_t{0}; nid<x[mid].size(); ++nid) {
-      x[mid][nid] = (x[mid][nid] - means_[nid]) / ranges_[nid];
+      auto value = x[mid][nid] - means_[nid];
+      x[mid][nid] = (ranges_[nid] == static_cast<T>(0)) ? value : value / ranges_[nid];
     }
   }
 }

--- a/src/ml_model.cc
+++ b/src/ml_model.cc
@@ -134,7 +134,7 @@ void MLModel<T>::GradientDescent(const std::vector<std::vector<T>> &x, const std
     // Computes the gradients and the updated parameters
     for (auto nid=size_t{0}; nid<n; ++nid) {
       auto gradient = Gradient(m, n, lambda, x, y, nid);
-      theta_temp[nid] = theta_[nid] - alpha * (1.0f/static_cast<T>(m)) * gradient;
+      theta_temp[nid] = theta_[nid] - alpha * gradient;
     }
 
     // Sets the new values for theta

--- a/src/ml_model.cc
+++ b/src/ml_model.cc
@@ -51,13 +51,15 @@ void MLModel<T>::ComputeNormalizations(const std::vector<std::vector<T>> &x) {
   for (auto nid=size_t{0}; nid<n; ++nid) {
     auto min = std::numeric_limits<T>::max();
     auto max = -min;
+    auto sum = static_cast<T>(0);
     for (auto mid=size_t{0}; mid<m; ++mid) {
       auto value = x[mid][nid];
       if (value > max) { max = value; }
       if (value < min) { min = value; }
+      sum += value;
     }
     ranges_[nid] = max - min;
-    means_[nid] = static_cast<T>(0); // TODO: implement this
+    means_[nid] = sum / static_cast<T>(m);
   }
 }
 

--- a/src/ml_model.cc
+++ b/src/ml_model.cc
@@ -146,10 +146,10 @@ void MLModel<T>::GradientDescent(const std::vector<std::vector<T>> &x, const std
 
 // =================================================================================================
 
-// Classifies all training examples for verification
+// Verifies training examples: computes the success rate within a specified margin
 template <typename T>
-float MLModel<T>::Verify(const std::vector<std::vector<T>> &x, const std::vector<T> &y,
-                         const float margin) const {
+float MLModel<T>::SuccessRate(const std::vector<std::vector<T>> &x, const std::vector<T> &y,
+                              const float margin) const {
   auto m = x.size();
   auto correct = 0;
   for (auto mid=size_t{0}; mid<m; ++mid) {
@@ -163,6 +163,22 @@ float MLModel<T>::Verify(const std::vector<std::vector<T>> &x, const std::vector
   return success_rate;
 }
 
+// Verifies training examples: computes the cost function
+template <typename T>
+float MLModel<T>::Verify(const std::vector<std::vector<T>> &x, const std::vector<T> &y) const {
+  auto m = x.size();
+  auto n = x[0].size();
+
+  // Displays the data
+  for (auto mid=size_t{0}; mid<m; ++mid) {
+    auto hypothesis = Hypothesis(x[mid]);
+    auto relative_error = (y[mid] - hypothesis) / (y[mid]);
+    printf("[ -------> ] Hypothesis: %7.3lf; Actual: %7.3lf; Error: %7.2lf%%\n", hypothesis, y[mid], 100.0f*relative_error);
+  }
+
+  // Computes the cost
+  return Cost(m, n, 0, x, y);
+}
 // =================================================================================================
 
 // Compiles the class

--- a/src/ml_model.cc
+++ b/src/ml_model.cc
@@ -1,0 +1,160 @@
+
+// =================================================================================================
+// This file is part of the CLTune project, which loosely follows the Google C++ styleguide and uses
+// a tab-size of two spaces and a max-width of 100 characters per line.
+//
+// Author: cedric.nugteren@surfsara.nl (Cedric Nugteren)
+//
+// This file implements the base MLModel class (see the header for information about the class).
+//
+// -------------------------------------------------------------------------------------------------
+//
+// Copyright 2014 SURFsara
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//  http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// =================================================================================================
+
+// The corresponding header file
+#include "internal/ml_model.h"
+
+#include <vector>
+#include <algorithm>
+
+namespace cltune {
+// =================================================================================================
+
+// Simple constructor
+template <typename T>
+MLModel<T>::MLModel(const size_t m, const size_t n):
+  ranges_(n, 1),
+  means_(n, 0) {
+}
+
+// =================================================================================================
+
+// Finds the ranges and the means for each feature
+template <typename T>
+void MLModel<T>::ComputeNormalizations(const std::vector<std::vector<T>> &x) {
+  auto m = x.size();
+  auto n = x[0].size();
+  for (auto nid=size_t{0}; nid<n; ++nid) {
+    auto min = std::numeric_limits<T>::max();
+    auto max = -min;
+    for (auto mid=size_t{0}; mid<m; ++mid) {
+      auto value = x[mid][nid];
+      if (value > max) { max = value; }
+      if (value < min) { min = value; }
+    }
+    ranges_[nid] = max - min;
+    means_[nid] = static_cast<T>(0); // TODO: implement this
+  }
+}
+
+// Normalizes the training features based on previously calculated ranges and means
+template <typename T>
+void MLModel<T>::NormalizeFeatures(std::vector<std::vector<T>> &x) {
+  auto m = x.size();
+  auto n = x[0].size();
+  for (auto nid=size_t{0}; nid<n; ++nid) {
+    for (auto mid=size_t{0}; mid<m; ++mid) {
+      auto value = x[mid][nid];
+      x[mid][nid] = (value - means_[nid]) / ranges_[nid];
+    }
+  }
+}
+
+// Adds polynominal combinations of features as new features
+template <typename T>
+void MLModel<T>::AddPolynominalFeatures(std::vector<std::vector<T>> &x, const size_t order) {
+  auto m = x.size();
+  auto n = x[0].size();
+  for (auto mid=size_t{0}; mid<m; ++mid) {
+
+    // TODO: For now only 2 supported
+    if (order == 2) {
+      x[mid].reserve(x[mid].size() + n*n);
+      for (auto nid1=size_t{0}; nid1<n; ++nid1) {
+        for (auto nid2=size_t{0}; nid2<n; ++nid2) {
+          x[mid].push_back(x[mid][nid1] * x[mid][nid2]);
+        }
+      }
+    }
+  }
+}
+
+// =================================================================================================
+
+// Implements the gradient descent iterative search algorithm. This method is based upon a cost-
+// function and gradient-function implemented by the derived class.
+template <typename T>
+void MLModel<T>::GradientDescent(const std::vector<std::vector<T>> &x, const std::vector<T> &y,
+                                 const T alpha, const size_t iterations) {
+  auto m = x.size();
+  auto n = x[0].size();
+
+  // Sets the initial theta values
+  // TODO: Move to a separate function
+  theta_.resize(n);
+  std::fill(theta_.begin(), theta_.end(), static_cast<T>(0));
+
+  // Runs gradient descent
+  for (auto iter=size_t{0}; iter<iterations; ++iter) {
+    auto theta_temp = std::vector<T>(n, static_cast<T>(0));
+
+    // Computes the cost (to monitor convergence)
+    auto cost = Cost(m, n, x, y);
+    if ((iter+1) % (iterations/kGradientDescentCostReportAmount) == 0) {
+      printf("%s Gradient descent %lu/%lu: cost %.2e\n",
+             TunerImpl::kMessageInfo.c_str(), iter+1, iterations, cost);
+    }
+    
+    // Computes the gradients and the updated parameters
+    for (auto nid=size_t{0}; nid<n; ++nid) {
+      auto gradient = Gradient(m, n, x, y, nid);
+      theta_temp[nid] = theta_[nid] - alpha * (1.0f/static_cast<T>(m)) * gradient;
+    }
+
+    // Sets the new values for theta
+    for (auto nid=size_t{0}; nid<n; ++nid) {
+      theta_[nid] = theta_temp[nid];
+    }
+  }
+}
+
+// =================================================================================================
+
+// Classifies all training examples for verification
+template <typename T>
+float MLModel<T>::Verify(const std::vector<std::vector<T>> &x, const std::vector<T> &y,
+                         const float margin) const {
+  auto m = x.size();
+  auto correct = 0;
+  for (auto mid=size_t{0}; mid<m; ++mid) {
+    auto hypothesis = Hypothesis(x[mid]);
+    auto limit_max = y[mid]*(1 + margin);
+    auto limit_min = y[mid]*(1 - margin);
+    if (hypothesis < limit_max && hypothesis > limit_min) { correct++; }
+    printf("[ -------> ] Hypothesis: %7.3lf; Actual: %7.3lf\n", hypothesis, y[mid]);
+  }
+  auto success_rate = 100.0f*correct/static_cast<float>(m);
+  return success_rate;
+}
+
+// =================================================================================================
+
+// Compiles the class
+template class MLModel<float>;
+
+// =================================================================================================
+} // namespace cltune

--- a/src/ml_models/linear_regression.cc
+++ b/src/ml_models/linear_regression.cc
@@ -36,8 +36,8 @@ namespace cltune {
 
 // Calls the base-class constructor
 template <typename T>
-LinearRegression<T>::LinearRegression(const size_t m, const size_t n):
-  MLModel<T>(m, n) {
+LinearRegression<T>::LinearRegression():
+  MLModel<T>() {
 }
 
 // =================================================================================================

--- a/src/ml_models/linear_regression.cc
+++ b/src/ml_models/linear_regression.cc
@@ -100,13 +100,13 @@ void LinearRegression<T>::PreProcessFeatures(std::vector<std::vector<T>> &x) con
 // Pre-processes the execution times using a logarithmic function
 template <typename T>
 void LinearRegression<T>::PreProcessExecutionTimes(std::vector<T> &y) const {
-  for (auto &value: y) { value = log(value); }
+  for (auto &value: y) { value = static_cast<T>(log(static_cast<double>(value))); }
 }
 
 // Post-processes an execution time using an exponent function (inverse of the logarithm)
 template <typename T>
 T LinearRegression<T>::PostProcessExecutionTime(T value) const {
-  return exp(value);
+  return static_cast<T>(exp(static_cast<double>(value)));
 }
 
 // =================================================================================================
@@ -126,6 +126,7 @@ T LinearRegression<T>::Hypothesis(const std::vector<T> &x) const {
   auto hypothesis = static_cast<T>(0);
   for (auto nid=size_t{0}; nid<n; ++nid) {
     hypothesis += theta_[nid] * x[nid];
+
   }
   return hypothesis;
 }
@@ -154,7 +155,7 @@ T LinearRegression<T>::Cost(const size_t m, const size_t n, const T lambda,
 
 // Gradient-function: computes the gradient of the cost-function with respect to a specific feature
 template <typename T>
-T LinearRegression<T>::Gradient(const size_t m, const size_t n, const T lambda,
+T LinearRegression<T>::Gradient(const size_t m, const size_t, const T lambda,
                                 const std::vector<std::vector<T>> &x, const std::vector<T> &y,
                                 const size_t gradient_id) const {
 

--- a/src/ml_models/linear_regression.cc
+++ b/src/ml_models/linear_regression.cc
@@ -52,7 +52,7 @@ void LinearRegression<T>::Train(const std::vector<std::vector<T>> &x, const std:
 
   // Runs gradient descent to train the model
   auto learning_rate = static_cast<T>(0.05);
-  auto lambda = static_cast<T>(0); // Regularization parameter
+  auto lambda = static_cast<T>(1); // Regularization parameter
   auto max_iterations = 800;
   GradientDescent(x_temp, y, learning_rate, lambda, max_iterations);
 
@@ -102,12 +102,22 @@ T LinearRegression<T>::Hypothesis(const std::vector<T> &x) const {
 template <typename T>
 T LinearRegression<T>::Cost(const size_t m, const size_t n, const T lambda,
                             const std::vector<std::vector<T>> &x, const std::vector<T> &y) const {
+
+  // Computes the sum of squared differences
   auto cost = static_cast<T>(0);
   for (auto mid=size_t{0}; mid<m; ++mid) {
     auto difference = Hypothesis(x[mid]) - y[mid];
     cost += difference * difference;
   }
-  return cost / (static_cast<T>(2) * static_cast<T>(m));
+
+  // Computes the squared sum of theta's (not counting theta-zero) for the regularization term
+  auto theta_squared_sum = static_cast<T>(0);
+  for (auto nid=size_t{1}; nid<n; ++nid) {
+    theta_squared_sum += theta_[nid] * theta_[nid];
+  }
+
+  // Computes the final cost
+  return (cost + lambda*theta_squared_sum) / (static_cast<T>(2) * static_cast<T>(m));
 }
 
 // Gradient-function: computes the gradient of the cost-function with respect to a specific feature
@@ -115,11 +125,15 @@ template <typename T>
 T LinearRegression<T>::Gradient(const size_t m, const size_t n, const T lambda,
                                 const std::vector<std::vector<T>> &x, const std::vector<T> &y,
                                 const size_t gradient_id) const {
+
+  // Computes the gradient of the cost function
   auto gradient = static_cast<T>(0);
   for (auto mid=size_t{0}; mid<m; ++mid) {
     gradient += (Hypothesis(x[mid]) - y[mid]) * x[mid][gradient_id];
   }
-  return gradient;
+
+  // Computes the final gradient with regularization
+  return (gradient / static_cast<T>(m)) + ((lambda * theta_[gradient_id]) / static_cast<T>(m));
 }
 
 // =================================================================================================

--- a/src/ml_models/linear_regression.cc
+++ b/src/ml_models/linear_regression.cc
@@ -1,0 +1,123 @@
+
+// =================================================================================================
+// This file is part of the CLTune project, which loosely follows the Google C++ styleguide and uses
+// a tab-size of two spaces and a max-width of 100 characters per line.
+//
+// Author: cedric.nugteren@surfsara.nl (Cedric Nugteren)
+//
+// This file implements the base MLModel class (see the header for information about the class).
+//
+// -------------------------------------------------------------------------------------------------
+//
+// Copyright 2014 SURFsara
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//  http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// =================================================================================================
+
+// The corresponding header file
+#include "internal/ml_models/linear_regression.h"
+
+#include <vector>
+
+namespace cltune {
+// =================================================================================================
+
+// Calls the base-class constructor
+template <typename T>
+LinearRegression<T>::LinearRegression(const size_t m, const size_t n):
+  MLModel<T>(m, n) {
+}
+
+// =================================================================================================
+
+// Trains the model
+template <typename T>
+void LinearRegression<T>::Train(const std::vector<std::vector<T>> &x, const std::vector<T> &y) {
+  auto x_temp = x;
+
+  // Modifies features to get a better model
+  ComputeNormalizations(x_temp);
+  NormalizeFeatures(x_temp);
+  AddPolynominalFeatures(x_temp, 2); // Second order
+
+  // Runs gradient descent to train the model
+  GradientDescent(x_temp, y, 0.05, 800);
+
+  // Verifies the trained results
+  auto margin = 0.10f; // 10%
+  auto success_rate = Verify(x_temp, y, margin);
+  printf("%s Training success rate: %.0lf%% with +/- %.0lf%% margin\n",
+         TunerImpl::kMessageResult.c_str(), success_rate, 100.0f*margin);
+}
+
+// Validates the model
+template <typename T>
+void LinearRegression<T>::Validate(const std::vector<std::vector<T>> &x, const std::vector<T> &y) {
+  auto x_temp = x;
+
+  // Modifies features according to the training data
+  NormalizeFeatures(x_temp);
+  AddPolynominalFeatures(x_temp, 2); // Second order
+
+  // Verifies the trained results
+  auto margin = 0.10f; // 10%
+  auto success_rate = Verify(x_temp, y, margin);
+  printf("%s Validation success rate: %.0lf%% with +/- %.0lf%% margin\n",
+         TunerImpl::kMessageResult.c_str(), success_rate, 100.0f*margin);
+}
+
+// =================================================================================================
+
+// Hypothesis-function: pass a single sample through the model and returns its hypothesis
+template <typename T>
+T LinearRegression<T>::Hypothesis(const std::vector<T> &x) const {
+  auto n = x.size();
+  auto hypothesis = static_cast<T>(0);
+  for (auto nid=size_t{0}; nid<n; ++nid) {
+    hypothesis += theta_[nid] * x[nid];
+  }
+  return hypothesis;
+}
+
+// Cost-function: computes the sum of squared differences
+template <typename T>
+T LinearRegression<T>::Cost(const size_t m, const size_t n,
+                            const std::vector<std::vector<T>> &x, const std::vector<T> &y) const {
+  auto cost = static_cast<T>(0);
+  for (auto mid=size_t{0}; mid<m; ++mid) {
+    auto difference = Hypothesis(x[mid]) - y[mid];
+    cost += difference * difference;
+  }
+  return cost / (static_cast<T>(2) * static_cast<T>(m));
+}
+
+// Gradient-function: computes the gradient of the cost-function with respect to a specific feature
+template <typename T>
+T LinearRegression<T>::Gradient(const size_t m, const size_t n,
+                                const std::vector<std::vector<T>> &x, const std::vector<T> &y,
+                                const size_t gradient_id) const {
+  auto gradient = static_cast<T>(0);
+  for (auto mid=size_t{0}; mid<m; ++mid) {
+    gradient += (Hypothesis(x[mid]) - y[mid]) * x[mid][gradient_id];
+  }
+  return gradient;
+}
+
+// =================================================================================================
+
+// Compiles the class
+template class LinearRegression<float>;
+
+// =================================================================================================
+} // namespace cltune

--- a/src/ml_models/linear_regression.cc
+++ b/src/ml_models/linear_regression.cc
@@ -29,6 +29,7 @@
 #include "internal/ml_models/linear_regression.h"
 
 #include <vector>
+#include <cmath>
 
 namespace cltune {
 // =================================================================================================
@@ -57,10 +58,8 @@ void LinearRegression<T>::Train(const std::vector<std::vector<T>> &x, const std:
   GradientDescent(x_temp, y, learning_rate, lambda, max_iterations);
 
   // Verifies the trained results
-  auto margin = 0.10f; // 10%
-  auto success_rate = Verify(x_temp, y, margin);
-  printf("%s Training success rate: %.0lf%% with +/- %.0lf%% margin\n",
-         TunerImpl::kMessageResult.c_str(), success_rate, 100.0f*margin);
+  auto cost = Verify(x_temp, y);
+  printf("%s Training cost: %.2e\n", TunerImpl::kMessageResult.c_str(), cost);
 }
 
 // Validates the model
@@ -72,10 +71,8 @@ void LinearRegression<T>::Validate(const std::vector<std::vector<T>> &x, const s
   PreProcessFeatures(x_temp);
 
   // Verifies the trained results
-  auto margin = 0.10f; // 10%
-  auto success_rate = Verify(x_temp, y, margin);
-  printf("%s Validation success rate: %.0lf%% with +/- %.0lf%% margin\n",
-         TunerImpl::kMessageResult.c_str(), success_rate, 100.0f*margin);
+  auto cost = Verify(x_temp, y);
+  printf("%s Validation cost: %.2e\n", TunerImpl::kMessageResult.c_str(), cost);
 }
 
 // Pre-processes the features based on normalization data

--- a/src/ml_models/neural_network.cc
+++ b/src/ml_models/neural_network.cc
@@ -1,0 +1,327 @@
+
+// =================================================================================================
+// This file is part of the CLTune project, which loosely follows the Google C++ styleguide and uses
+// a tab-size of two spaces and a max-width of 100 characters per line.
+//
+// Author: cedric.nugteren@surfsara.nl (Cedric Nugteren)
+//
+// This file implements the NeuralNetwork class (see the header for information about the class).
+//
+// -------------------------------------------------------------------------------------------------
+//
+// Copyright 2014 SURFsara
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//  http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// =================================================================================================
+
+// The corresponding header file
+#include "internal/ml_models/neural_network.h"
+
+#include <vector>
+#include <cmath>
+#include <random>
+#include <exception>
+
+namespace cltune {
+// =================================================================================================
+
+// Calls the base-class constructor
+template <typename T>
+NeuralNetwork<T>::NeuralNetwork(const size_t learning_iterations, const T learning_rate,
+                                const T lambda, const std::vector<size_t> &layer_sizes,
+                                const bool debug_display):
+    MLModel<T>(debug_display),
+    num_layers_(layer_sizes.size()),
+    layer_sizes_(layer_sizes),
+    learning_iterations_(learning_iterations),
+    learning_rate_(learning_rate),
+    lambda_(lambda) {
+  if (num_layers_ != 3) { throw std::runtime_error("Only supporting networks with 3 layers"); }
+}
+
+// =================================================================================================
+
+// Trains the model
+template <typename T>
+void NeuralNetwork<T>::Train(const std::vector<std::vector<T>> &x, const std::vector<T> &y) {
+  auto x_temp = x;
+  auto y_temp = y;
+
+  // Modifies data to get a better model
+  ComputeNormalizations(x_temp);
+  PreProcessFeatures(x_temp);
+  PreProcessExecutionTimes(y_temp);
+
+  // Runs gradient descent to train the model
+  GradientDescent(x_temp, y_temp, learning_rate_, lambda_, learning_iterations_);
+
+  // Verifies and displays the trained results
+  auto cost = Verify(x_temp, y_temp);
+  printf("%s Training cost: %.2e\n", TunerImpl::kMessageResult.c_str(), cost);
+}
+
+// Validates the model
+template <typename T>
+void NeuralNetwork<T>::Validate(const std::vector<std::vector<T>> &x, const std::vector<T> &y) {
+  auto x_temp = x;
+  auto y_temp = y;
+
+  // Modifies validation data in the same way as the training data
+  PreProcessFeatures(x_temp);
+  PreProcessExecutionTimes(y_temp);
+
+  // Verifies and displays the trained results
+  auto cost = Verify(x_temp, y_temp);
+  printf("%s Validation cost: %.2e\n", TunerImpl::kMessageResult.c_str(), cost);
+}
+
+// Prediction: pre-processe a single sample and pass it through the model
+template <typename T>
+T NeuralNetwork<T>::Predict(const std::vector<T> &x) const {
+  auto x_preprocessed = std::vector<std::vector<T>>{x};
+  PreProcessFeatures(x_preprocessed);
+  return PostProcessExecutionTime(Hypothesis(x_preprocessed[0]));
+}
+
+// =================================================================================================
+
+// Pre-processes the features based on normalization data
+template <typename T>
+void NeuralNetwork<T>::PreProcessFeatures(std::vector<std::vector<T>> &x) const {
+  NormalizeFeatures(x);
+}
+
+// Pre-processes the execution times using a logarithmic function
+template <typename T>
+void NeuralNetwork<T>::PreProcessExecutionTimes(std::vector<T> &y) const {
+  for (auto &value: y) { value = static_cast<T>(log(static_cast<double>(value))); }
+}
+
+// Post-processes an execution time using an exponent function (inverse of the logarithm)
+template <typename T>
+T NeuralNetwork<T>::PostProcessExecutionTime(T value) const {
+  return static_cast<T>(exp(static_cast<double>(value)));
+}
+
+// =================================================================================================
+
+// Initialization-function: sets the initial weights theta
+template <typename T>
+void NeuralNetwork<T>::InitializeTheta(const size_t n) {
+
+  // Resizes the weight matrices theta
+  if (layer_sizes_[0] != n) { throw std::runtime_error("Invalid size of the first layer"); }
+  if (layer_sizes_[2] != 1) { throw std::runtime_error("Invalid size of the third layer"); }
+  theta1_.resize((layer_sizes_[0]+1)*layer_sizes_[1]);
+  theta2_.resize((layer_sizes_[1]+1)*layer_sizes_[2]);
+
+  // Calculates the random-initialization range
+  auto epsilon1 = static_cast<T>(sqrt(static_cast<T>(6))/sqrt(static_cast<T>(layer_sizes_[0]+layer_sizes_[1])));
+  auto epsilon2 = static_cast<T>(sqrt(static_cast<T>(6))/sqrt(static_cast<T>(layer_sizes_[1]+layer_sizes_[2])));
+  
+  // Creates a random number generator
+  const auto random_seed = std::chrono::system_clock::now().time_since_epoch().count();
+  std::default_random_engine generator(static_cast<unsigned int>(random_seed));
+  std::uniform_real_distribution<T> distribution1(-epsilon1, epsilon1);
+  std::uniform_real_distribution<T> distribution2(-epsilon2, epsilon2);
+
+  // Fills the weights with random values
+  for (auto &weight: theta1_) { weight = distribution1(generator); }
+  for (auto &weight: theta2_) { weight = distribution2(generator); }
+}
+
+// =================================================================================================
+
+// Hypothesis-function: pass a single sample through the model and returns its hypothesis
+// TODO: Memory usage and performance can be improved
+template <typename T>
+T NeuralNetwork<T>::Hypothesis(const std::vector<T> &x) const {
+
+  // Adds a bias to the input data
+  auto a0 = FeedForward0(x);
+  
+  // Performs the activations of the first hidden layer
+  auto a1 = FeedForward1(a0, true);
+  
+  // Performs the activations of the output layer
+  auto a2 = FeedForward2(a1);
+
+  // Only one output supported
+  if (layer_sizes_[2] != 1) { throw std::runtime_error("Invalid size of the third layer"); }
+  auto hypothesis = a2[0];
+  return hypothesis;
+}
+
+// Cost-function: computes the sum of squared differences
+template <typename T>
+T NeuralNetwork<T>::Cost(const size_t m, const size_t, const T lambda,
+                         const std::vector<std::vector<T>> &x, const std::vector<T> &y) const {
+
+  // Computes the sum of squared differences
+  auto cost = static_cast<T>(0);
+  for (auto mid=size_t{0}; mid<m; ++mid) {
+    auto difference = Hypothesis(x[mid]) - y[mid];
+    cost += difference * difference;
+  }
+  cost /= static_cast<T>(m);
+
+  // Computes the squared sum of theta's (not counting theta-zero) for the regularization term
+  auto theta_squared_sum = static_cast<T>(0);
+  for (auto id1=size_t{0}; id1<layer_sizes_[1]; ++id1) {
+    for (auto id0=size_t{1}; id0<layer_sizes_[0]+1; ++id0) {
+      auto value = theta1_[id1*(layer_sizes_[0]+1) + id0];
+      theta_squared_sum += value * value;
+    }
+  }
+  for (auto id2=size_t{0}; id2<layer_sizes_[2]; ++id2) {
+    for (auto id1=size_t{1}; id1<layer_sizes_[1]+1; ++id1) {
+      auto value = theta2_[id2*(layer_sizes_[1]+1) + id1];
+      theta_squared_sum += value * value;
+    }
+  }
+
+  // Computes the final cost
+  return cost + (lambda*theta_squared_sum) / (static_cast<T>(2 * m));
+}
+
+// Gradient-function: computes the gradient of the cost-function
+template <typename T>
+void NeuralNetwork<T>::Gradient(const size_t m, const size_t, const T lambda, const T alpha,
+                                const std::vector<std::vector<T>> &x, const std::vector<T> &y) {
+
+  // Temporary data storage for the gradients
+  auto gradient1 = std::vector<T>(theta1_.size(), static_cast<T>(0));
+  auto gradient2 = std::vector<T>(theta2_.size(), static_cast<T>(0));
+
+  // Loops over all samples of the training data
+  for (auto mid=size_t{0}; mid<m; ++mid) {
+
+    // Performs the feed-forward computations (with and without sigmoid)
+    auto a0 = FeedForward0(x[mid]);
+    auto z1 = FeedForward1(a0, false);
+    auto a1 = FeedForward1(a0, true);
+    auto a2 = FeedForward2(a1);
+
+    // Computes the error at the last layer
+    auto d2 = std::vector<T>(layer_sizes_[2]);
+    if (layer_sizes_[2] != 1) { throw std::runtime_error("Invalid size of the third layer"); }
+    d2[0] = a2[0] - y[mid];
+
+    // Propagates the error back (backpropagation) to compute the delta at the hidden layer
+    auto d1 = std::vector<T>(layer_sizes_[1]);
+    for (auto id1=size_t{1}; id1<layer_sizes_[1]+1; ++id1) {
+      auto value = static_cast<T>(0);
+      for (auto id2=size_t{0}; id2<layer_sizes_[2]; ++id2) {
+        value += d2[id2] * theta2_[id2*(layer_sizes_[1]+1) + id1];
+      }
+      d1[id1-1] = value * SigmoidGradient(z1[id1]);
+    }
+
+    // Accumulates the partial gradients
+    for (auto id0=size_t{0}; id0<layer_sizes_[0]+1; ++id0) {
+      for (auto id1=size_t{0}; id1<layer_sizes_[1]; ++id1) {
+        gradient1[id1*(layer_sizes_[0]+1) + id0] += d1[id1] * a0[id0];
+      }
+    }
+    for (auto id1=size_t{0}; id1<layer_sizes_[1]+1; ++id1) {
+      for (auto id2=size_t{0}; id2<layer_sizes_[2]; ++id2) {
+        gradient2[id2*(layer_sizes_[1]+1) + id1] += d2[id2] * a1[id1];
+      }
+    }
+  }
+
+  // Computes the final gradients, adding regularization
+  for (auto id0=size_t{0}; id0<layer_sizes_[0]+1; ++id0) {
+    for (auto id1=size_t{0}; id1<layer_sizes_[1]; ++id1) {
+      auto index = id1*(layer_sizes_[0]+1) + id0;
+      if (id0 != 0) { // Don't add regularization for the bias term
+        gradient1[index] += lambda * theta1_[index];
+      }
+      gradient1[index] /= static_cast<T>(m);
+    }
+  }
+  for (auto id1=size_t{0}; id1<layer_sizes_[1]+1; ++id1) {
+    for (auto id2=size_t{0}; id2<layer_sizes_[2]; ++id2) {
+      auto index = id2*(layer_sizes_[1]+1) + id1;
+      if (id1 != 0) { // Don't add regularization for the bias term
+        gradient2[index] += lambda * theta2_[index];
+      }
+      gradient2[index] /= static_cast<T>(m);
+    }
+  }
+
+  // Sets the new values of theta
+  for (auto id0=size_t{0}; id0<layer_sizes_[0]+1; ++id0) {
+    for (auto id1=size_t{0}; id1<layer_sizes_[1]; ++id1) {
+      auto index = id1*(layer_sizes_[0]+1) + id0;
+      theta1_[index] = theta1_[index] - alpha * gradient1[index];
+    }
+  }
+  for (auto id1=size_t{0}; id1<layer_sizes_[1]+1; ++id1) {
+    for (auto id2=size_t{0}; id2<layer_sizes_[2]; ++id2) {
+      auto index = id2*(layer_sizes_[1]+1) + id1;
+      theta2_[index] = theta2_[index] - alpha * gradient2[index];
+    }
+  }
+}
+
+// =================================================================================================
+
+// Feed-forward function: input layer (with bias unit)
+template <typename T>
+std::vector<T> NeuralNetwork<T>::FeedForward0(const std::vector<T> &x) const {
+  auto a0 = std::vector<T>(layer_sizes_[0]+1);
+  a0[0] = static_cast<T>(1);
+  for (auto id0=size_t{0}; id0<layer_sizes_[0]; ++id0) {
+    a0[id0 + 1] = x[id0];
+  }
+  return a0;
+}
+
+// Feed-forward function: hidden layer (with bias unit and optionally a sigmoid activation function)
+template <typename T>
+std::vector<T> NeuralNetwork<T>::FeedForward1(const std::vector<T> &a0, const bool sigmoid) const {
+  auto a1 = std::vector<T>(layer_sizes_[1]+1);
+  a1[0] = static_cast<T>(1);
+  for (auto id1=size_t{0}; id1<layer_sizes_[1]; ++id1) {
+    auto z1 = static_cast<T>(0);
+    for (auto id0=size_t{0}; id0<layer_sizes_[0]+1; ++id0) {
+      z1 += a0[id0] * theta1_[id1*(layer_sizes_[0]+1) + id0];
+    }
+    a1[id1 + 1] = (sigmoid) ? Sigmoid(z1) : z1;
+  }
+  return a1;
+}
+
+// Feed-forward function: output layer
+template <typename T>
+std::vector<T> NeuralNetwork<T>::FeedForward2(const std::vector<T> &a1) const {
+  auto a2 = std::vector<T>(layer_sizes_[2]);
+  for (auto id2=size_t{0}; id2<layer_sizes_[2]; ++id2) {
+    auto z2 = static_cast<T>(0);
+    for (auto id1=size_t{0}; id1<layer_sizes_[1]+1; ++id1) {
+      z2 += a1[id1] * theta2_[id2*(layer_sizes_[1]+1) + id1];
+    }
+    a2[id2] = z2; // No sigmoid activation function in the output layer
+  }
+  return a2;
+}
+
+// =================================================================================================
+
+// Compiles the class
+template class NeuralNetwork<float>;
+
+// =================================================================================================
+} // namespace cltune

--- a/src/tuner_impl.cc
+++ b/src/tuner_impl.cc
@@ -41,6 +41,8 @@
 #include <iostream> // FILE
 #include <limits> // std::numeric_limits
 #include <algorithm> // std::min
+#include <memory> // std::unique_ptr
+#include <tuple> // std::tuple
 
 namespace cltune {
 // =================================================================================================
@@ -185,7 +187,7 @@ void TunerImpl::Tune() {
         auto tuning_result = RunKernel(source, kernel, p, search->NumConfigurations());
         tuning_result.status = VerifyOutput();
 
-        // Gives timing feedback to the search algorithm and calculate the next index
+        // Gives timing feedback to the search algorithm and calculates the next index
         search->PushExecutionTime(tuning_result.time);
         search->CalculateNextIndex();
 
@@ -430,43 +432,118 @@ template <> double TunerImpl::AbsoluteDifference(const double2 reference, const 
 // =================================================================================================
 
 // Trains a model and predicts all remaining configurations
-void TunerImpl::ModelPrediction(const Model model) {
+void TunerImpl::ModelPrediction(const Model model_type, const float validation_fraction,
+                                const size_t test_top_x_configurations) {
 
-  // Retrieves the number of training samples and features
-  auto validation_samples_fraction = 0.20f; // 20%
-  auto validation_samples = static_cast<size_t>(tuning_results_.size()*validation_samples_fraction);
-  auto training_samples = tuning_results_.size() - validation_samples;
-  auto features = tuning_results_[0].configuration.size();
+  // Iterates over all tunable kernels
+  for (auto &kernel: kernels_) {
 
-  // Sets the raw training and validation data
-  auto x_train = std::vector<std::vector<float>>(training_samples, std::vector<float>(features));
-  auto y_train = std::vector<float>(training_samples);
-  for (auto s=size_t{0}; s<training_samples; ++s) {
-    y_train[s] = tuning_results_[s].time;
-    for (auto f=size_t{0}; f<features; ++f) {
-      x_train[s][f] = static_cast<float>(tuning_results_[s].configuration[f].value);
+    // Retrieves the number of training samples and features
+    auto validation_fraction = 0.20f; // 20%
+    auto validation_samples = static_cast<size_t>(tuning_results_.size()*validation_fraction);
+    auto training_samples = tuning_results_.size() - validation_samples;
+    auto features = tuning_results_[0].configuration.size();
+
+    // Sets the raw training and validation data
+    auto x_train = std::vector<std::vector<float>>(training_samples, std::vector<float>(features));
+    auto y_train = std::vector<float>(training_samples);
+    for (auto s=size_t{0}; s<training_samples; ++s) {
+      y_train[s] = tuning_results_[s].time;
+      for (auto f=size_t{0}; f<features; ++f) {
+        x_train[s][f] = static_cast<float>(tuning_results_[s].configuration[f].value);
+      }
     }
-  }
-  auto x_validation = std::vector<std::vector<float>>(validation_samples, std::vector<float>(features));
-  auto y_validation = std::vector<float>(validation_samples);
-  for (auto s=size_t{0}; s<validation_samples; ++s) {
-    y_validation[s] = tuning_results_[s+training_samples].time;
-    for (auto f=size_t{0}; f<features; ++f) {
-      x_validation[s][f] = static_cast<float>(tuning_results_[s + training_samples].configuration[f].value);
+    auto x_validation = std::vector<std::vector<float>>(validation_samples, std::vector<float>(features));
+    auto y_validation = std::vector<float>(validation_samples);
+    for (auto s=size_t{0}; s<validation_samples; ++s) {
+      y_validation[s] = tuning_results_[s+training_samples].time;
+      for (auto f=size_t{0}; f<features; ++f) {
+        x_validation[s][f] = static_cast<float>(tuning_results_[s + training_samples].configuration[f].value);
+      }
     }
-  }
 
-  // Linear regression
-  if (model == Model::kLinearRegression) {
-    PrintHeader("Training a linear regression model");
-    auto model = LinearRegression<float>();
-    model.Train(x_train, y_train);
-    model.Validate(x_validation, y_validation);
-  }
+    // Pointer to one of the machine learning models
+    std::unique_ptr<MLModel<float>> model;
 
-  // Unknown model
-  else {
-    throw std::runtime_error("Unknown machine learning model");
+    // Sets the learning parameters
+    auto learning_iterations = 800UL; // For gradient descent
+    auto learning_rate = 0.05f; // For gradient descent
+    auto lambda = 0.5f; // Regularization parameter
+    auto debug_display = true; // Output learned data to stdout
+
+    // Trains a linear regression model
+    if (model_type == Model::kLinearRegression) {
+      PrintHeader("Training a linear regression model");
+      model = std::unique_ptr<MLModel<float>>(
+        new LinearRegression<float>(learning_iterations, learning_rate, lambda, debug_display)
+      );
+      model->Train(x_train, y_train);
+      model->Validate(x_validation, y_validation);
+    }
+
+    // Unknown model
+    else {
+      throw std::runtime_error("Unknown machine learning model");
+    }
+
+    // Iterates over all configurations (the permutations of the tuning parameters)
+    PrintHeader("Predicting the remaining configurations using the model");
+    auto model_results = std::vector<std::tuple<size_t,float>>();
+    auto p = size_t{0};
+    for (auto &permutation: kernel.configurations()) {
+
+      // Runs the trained model to predicts the result
+      auto x_test = std::vector<float>();
+      for (auto &setting: permutation) {
+        x_test.push_back(static_cast<float>(setting.value));
+      }
+      auto predicted_time = model->Predict(x_test);
+      model_results.push_back(std::make_tuple(p, predicted_time));
+      ++p;
+    }
+
+    // Sorts the modelled results by performance
+    std::sort(begin(model_results), end(model_results),
+      [](const std::tuple<size_t,float> &t1, const std::tuple<size_t,float> &t2) {
+        return std::get<1>(t1) < std::get<1>(t2);
+      }
+    );
+
+    // Tests the best configurations on the device to verify the results
+    PrintHeader("Testing the best-found configurations");
+    for (auto i=size_t{0}; i<test_top_x_configurations && i<model_results.size(); ++i) {
+      auto result = model_results[i];
+      printf("[ -------> ] The model predicted: %.3lf ms\n", std::get<1>(result));
+      auto p = std::get<0>(result);
+      auto permutations = kernel.configurations();
+      auto permutation = permutations[p];
+
+      // Adds the parameters to the source-code string as defines
+      auto source = std::string{};
+      for (auto &config: permutation) {
+        source += config.GetDefine();
+      }
+      source += kernel.source();
+
+      // Updates the local range with the parameter values
+      kernel.ComputeRanges(permutation);
+
+      // Compiles and runs the kernel
+      auto tuning_result = RunKernel(source, kernel, p, test_top_x_configurations);
+      tuning_result.status = VerifyOutput();
+
+      // Stores the parameters and the timing-result
+      tuning_result.configuration = permutation;
+      tuning_results_.push_back(tuning_result);
+      if (tuning_result.time == std::numeric_limits<double>::max()) {
+        tuning_result.time = 0.0;
+        PrintResult(stdout, tuning_result, kMessageFailure);
+        tuning_result.time = std::numeric_limits<double>::max();
+      }
+      else if (!tuning_result.status) {
+        PrintResult(stdout, tuning_result, kMessageWarning);
+      }
+    }
   }
 }
 

--- a/src/tuner_impl.cc
+++ b/src/tuner_impl.cc
@@ -194,10 +194,10 @@ void TunerImpl::Tune() {
         // Stores the parameters and the timing-result
         tuning_result.configuration = permutation;
         tuning_results_.push_back(tuning_result);
-        if (tuning_result.time == std::numeric_limits<double>::max()) {
+        if (tuning_result.time == std::numeric_limits<float>::max()) {
           tuning_result.time = 0.0;
           PrintResult(stdout, tuning_result, kMessageFailure);
-          tuning_result.time = std::numeric_limits<double>::max();
+          tuning_result.time = std::numeric_limits<float>::max();
         }
         else if (!tuning_result.status) {
           PrintResult(stdout, tuning_result, kMessageWarning);
@@ -439,7 +439,6 @@ void TunerImpl::ModelPrediction(const Model model_type, const float validation_f
   for (auto &kernel: kernels_) {
 
     // Retrieves the number of training samples and features
-    auto validation_fraction = 0.20f; // 20%
     auto validation_samples = static_cast<size_t>(tuning_results_.size()*validation_fraction);
     auto training_samples = tuning_results_.size() - validation_samples;
     auto features = tuning_results_[0].configuration.size();
@@ -514,9 +513,9 @@ void TunerImpl::ModelPrediction(const Model model_type, const float validation_f
     for (auto i=size_t{0}; i<test_top_x_configurations && i<model_results.size(); ++i) {
       auto result = model_results[i];
       printf("[ -------> ] The model predicted: %.3lf ms\n", std::get<1>(result));
-      auto p = std::get<0>(result);
+      auto pid = std::get<0>(result);
       auto permutations = kernel.configurations();
-      auto permutation = permutations[p];
+      auto permutation = permutations[pid];
 
       // Adds the parameters to the source-code string as defines
       auto source = std::string{};
@@ -529,16 +528,16 @@ void TunerImpl::ModelPrediction(const Model model_type, const float validation_f
       kernel.ComputeRanges(permutation);
 
       // Compiles and runs the kernel
-      auto tuning_result = RunKernel(source, kernel, p, test_top_x_configurations);
+      auto tuning_result = RunKernel(source, kernel, pid, test_top_x_configurations);
       tuning_result.status = VerifyOutput();
 
       // Stores the parameters and the timing-result
       tuning_result.configuration = permutation;
       tuning_results_.push_back(tuning_result);
-      if (tuning_result.time == std::numeric_limits<double>::max()) {
+      if (tuning_result.time == std::numeric_limits<float>::max()) {
         tuning_result.time = 0.0;
         PrintResult(stdout, tuning_result, kMessageFailure);
-        tuning_result.time = std::numeric_limits<double>::max();
+        tuning_result.time = std::numeric_limits<float>::max();
       }
       else if (!tuning_result.status) {
         PrintResult(stdout, tuning_result, kMessageWarning);

--- a/src/tuner_impl.cc
+++ b/src/tuner_impl.cc
@@ -36,6 +36,7 @@
 
 // The machine learning models
 #include "internal/ml_models/linear_regression.h"
+#include "internal/ml_models/neural_network.h"
 
 #include <fstream> // std::ifstream, std::stringstream
 #include <iostream> // FILE
@@ -464,17 +465,38 @@ void TunerImpl::ModelPrediction(const Model model_type, const float validation_f
     // Pointer to one of the machine learning models
     std::unique_ptr<MLModel<float>> model;
 
-    // Sets the learning parameters
-    auto learning_iterations = 800UL; // For gradient descent
-    auto learning_rate = 0.05f; // For gradient descent
-    auto lambda = 0.5f; // Regularization parameter
-    auto debug_display = true; // Output learned data to stdout
-
     // Trains a linear regression model
     if (model_type == Model::kLinearRegression) {
       PrintHeader("Training a linear regression model");
+
+      // Sets the learning parameters
+      auto learning_iterations = 800UL; // For gradient descent
+      auto learning_rate = 0.05f; // For gradient descent
+      auto lambda = 0.2f; // Regularization parameter
+      auto debug_display = true; // Output learned data to stdout
+
+      // Trains and validates the model
       model = std::unique_ptr<MLModel<float>>(
         new LinearRegression<float>(learning_iterations, learning_rate, lambda, debug_display)
+      );
+      model->Train(x_train, y_train);
+      model->Validate(x_validation, y_validation);
+    }
+
+    // Trains a neural network model
+    else if (model_type == Model::kNeuralNetwork) {
+      PrintHeader("Training a neural network model");
+
+      // Sets the learning parameters
+      auto learning_iterations = 800UL; // For gradient descent
+      auto learning_rate = 0.1f; // For gradient descent
+      auto lambda = 0.005f; // Regularization parameter
+      auto debug_display = true; // Output learned data to stdout
+      auto layers = std::vector<size_t>{features, 20, 1};
+
+      // Trains and validates the model
+      model = std::unique_ptr<MLModel<float>>(
+        new NeuralNetwork<float>(learning_iterations, learning_rate, lambda, layers, debug_display)
       );
       model->Train(x_train, y_train);
       model->Validate(x_validation, y_validation);

--- a/src/tuner_impl.cc
+++ b/src/tuner_impl.cc
@@ -433,7 +433,8 @@ template <> double TunerImpl::AbsoluteDifference(const double2 reference, const 
 void TunerImpl::ModelPrediction(const Model model) {
 
   // Retrieves the number of training samples and features
-  auto validation_samples = size_t{8};
+  auto validation_samples_fraction = 0.20f; // 20%
+  auto validation_samples = static_cast<size_t>(tuning_results_.size()*validation_samples_fraction);
   auto training_samples = tuning_results_.size() - validation_samples;
   auto features = tuning_results_[0].configuration.size();
 
@@ -458,12 +459,8 @@ void TunerImpl::ModelPrediction(const Model model) {
   // Linear regression
   if (model == Model::kLinearRegression) {
     PrintHeader("Training a linear regression model");
-    auto model = LinearRegression<float>(training_samples, features);
-
-    // Trains the model
+    auto model = LinearRegression<float>();
     model.Train(x_train, y_train);
-
-    // Validates the model
     model.Validate(x_validation, y_validation);
   }
 


### PR DESCRIPTION
Added support for a first version of machine learning models. These models can be trained on a small fraction of the tuning configurations and can be used to predict the remainder. Two models are supported:
- Linear regression
- A 3-layer neural network