### PR TITLE
Updated the CLCudaAPI header

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Development version (next release)
   tuning configurations and can be used to predict the remainder. Two models are supported:
   * Linear regression
   * A 3-layer neural network
+- Added experimental support for CUDA kernels
 - Various minor fixes
 
 Version 1.7.1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 
 Development version (next release)
-- 
+- Now using version 4.0 of the CLCudaAPI header (previously Claduc)
+- Added support for machine learning models. These models can be trained on a small fraction of the
+  tuning configurations and can be used to predict the remainder. Two models are supported:
+  * Linear regression
+  * A 3-layer neural network
+- Various minor fixes
 
 Version 1.7.1
 - Added additional device properties to JSON-output

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(FLAGS "${FLAGS} -Wno-missing-prototypes -Wno-float-equal -Wno-weak-vtables")
   set(FLAGS "${FLAGS} -Wno-exit-time-destructors -Wno-global-constructors -Wno-missing-prototypes")
   set(FLAGS "${FLAGS} -Wno-missing-noreturn -Wno-covered-switch-default")
+  set(FLAGS "${FLAGS} -Wno-non-virtual-dtor -Wno-weak-template-vtables")
 endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@
 # ==================================================================================================
 # This file is part of the CLTune project.
 #
-# Author: cedric.nugteren@surfsara.nl (Cedric Nugteren)
+# Author(s):
+#   Cedric Nugteren <www.cedricnugteren.nl>
 #
 # -------------------------------------------------------------------------------------------------
 #
@@ -32,6 +33,15 @@ set(cltune_VERSION_PATCH 1)
 # Options
 option(SAMPLES "Enable compilation of sample programs" ON)
 option(TESTS "Enable compilation of the Google tests" OFF)
+
+# Select between OpenCL and CUDA back-end
+option(USE_OPENCL "Use OpenCL instead of CUDA" ON)
+if(USE_OPENCL)
+  message("-- Building with OpenCL")
+  add_definitions(-DUSE_OPENCL)
+else()
+  message("-- Building with CUDA")
+endif()
 
 # ==================================================================================================
 
@@ -74,11 +84,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(FLAGS "${FLAGS} -Wno-attributes")
   endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  set(FLAGS "${FLAGS} -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-padded")
-  set(FLAGS "${FLAGS} -Wno-missing-prototypes -Wno-float-equal -Wno-weak-vtables")
-  set(FLAGS "${FLAGS} -Wno-exit-time-destructors -Wno-global-constructors -Wno-missing-prototypes")
-  set(FLAGS "${FLAGS} -Wno-missing-noreturn -Wno-covered-switch-default")
-  set(FLAGS "${FLAGS} -Wno-non-virtual-dtor -Wno-weak-template-vtables")
+  set(FLAGS "${FLAGS} -Wextra")
 endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS}")
 
@@ -87,13 +93,26 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS}")
 # Package scripts location
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
-# Requires OpenCL (FindOpenCL is included as part of this project)
-find_package(OpenCL REQUIRED)
+# Requires CUDA or OpenCL. The latter is found through the included "FindOpenCL.cmake".
+if(USE_OPENCL)
+  find_package(OpenCL REQUIRED)
+  set(FRAMEWORK_INCLUDE_DIRS ${OPENCL_INCLUDE_DIRS})
+  set(FRAMEWORK_LIBRARY_DIRS )
+  set(FRAMEWORK_LIBRARIES ${OPENCL_LIBRARIES})
+else()
+  find_package(CUDA REQUIRED)
+  set(FRAMEWORK_INCLUDE_DIRS ${CUDA_INCLUDE_DIRS})
+  set(FRAMEWORK_LIBRARY_DIRS ${CUDA_TOOLKIT_ROOT_DIR}/lib64)
+  set(FRAMEWORK_LIBRARIES cuda nvrtc)
+endif()
 
 # ==================================================================================================
 
-# The includes
-include_directories(${cltune_SOURCE_DIR}/include ${OPENCL_INCLUDE_DIRS})
+# Include directories: CLTune headers and OpenCL/CUDA includes
+include_directories(${cltune_SOURCE_DIR}/include ${FRAMEWORK_INCLUDE_DIRS})
+
+# Link directories: CUDA toolkit
+link_directories(${FRAMEWORK_LIBRARY_DIRS})
 
 # Gathers all source-files
 set(TUNER
@@ -111,7 +130,7 @@ set(TUNER
 
 # Creates and links the library
 add_library(cltune SHARED ${TUNER})
-target_link_libraries(cltune ${OPENCL_LIBRARIES})
+target_link_libraries(cltune ${FRAMEWORK_LIBRARIES})
 
 # Installs the library
 install(TARGETS cltune DESTINATION lib)
@@ -125,9 +144,9 @@ if (SAMPLES)
   add_executable(sample_simple samples/simple/simple.cc)
   add_executable(sample_gemm samples/gemm/gemm.cc)
   add_executable(sample_conv samples/conv/conv.cc)
-  target_link_libraries(sample_simple cltune ${OPENCL_LIBRARIES} ${OpenMP_LIBRARY})
-  target_link_libraries(sample_gemm cltune ${OPENCL_LIBRARIES} ${OpenMP_LIBRARY})
-  target_link_libraries(sample_conv cltune ${OPENCL_LIBRARIES} ${OpenMP_LIBRARY})
+  target_link_libraries(sample_simple cltune ${FRAMEWORK_LIBRARIES} ${OpenMP_LIBRARY})
+  target_link_libraries(sample_gemm cltune ${FRAMEWORK_LIBRARIES} ${OpenMP_LIBRARY})
+  target_link_libraries(sample_conv cltune ${FRAMEWORK_LIBRARIES} ${OpenMP_LIBRARY})
 
   # Note: these are not installed because they depend on their separate OpenCL kernel files
 
@@ -146,7 +165,7 @@ if (TESTS)
 
   # Compiles the tests
   add_executable(unit_tests test/tuner.cc test/kernel_info.cc)
-  target_link_libraries(unit_tests gtest gtest_main cltune ${OPENCL_LIBRARIES})
+  target_link_libraries(unit_tests gtest gtest_main cltune ${FRAMEWORK_LIBRARIES})
 
   # Adds the tests
   add_test(name unit_tests command unit_tests)

--- a/include/cltune.h
+++ b/include/cltune.h
@@ -106,7 +106,7 @@ class Tuner {
                            const std::vector<std::string> &parameters);
 
   // Functions to add kernel-arguments for input buffers, output buffers, and scalars. Make sure to
-  // call these in the order in which the arguments appear in the OpenCL kernel.
+  // call these in the order in which the arguments appear in the kernel.
   template <typename T> void AddArgumentInput(const std::vector<T> &source);
   template <typename T> void AddArgumentOutput(const std::vector<T> &source);
   template <typename T> void AddArgumentScalar(const T argument);

--- a/include/internal/cupp11.h
+++ b/include/internal/cupp11.h
@@ -1,0 +1,603 @@
+
+// =================================================================================================
+// This file is part of the CLTune project, which loosely follows the Google C++ styleguide and uses
+// a tab-size of two spaces and a max-width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file implements a bunch of C++11 classes that act as wrappers around CUDA objects and API
+// calls. The main benefits are increased abstraction, automatic memory management, and portability.
+// Portability here means that a similar header exists for OpenCL with the same classes and
+// interfaces. In other words, moving from the CUDA API to the OpenCL API becomes a one-line change.
+//
+// This is version 4.0 of CLCudaAPI <https://github.com/CNugteren/CLCudaAPI>.
+//
+// =================================================================================================
+//
+// Copyright 2015 SURFsara
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//  http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// =================================================================================================
+
+#ifndef CLTUNE_CUPP11_H_
+#define CLTUNE_CUPP11_H_
+
+// C++
+#include <algorithm> // std::copy
+#include <string>    // std::string
+#include <vector>    // std::vector
+#include <memory>    // std::shared_ptr
+#include <stdexcept> // std::runtime_error
+
+// CUDA
+#include <cuda.h>    // CUDA driver API
+#include <nvrtc.h>   // NVIDIA runtime compilation API
+
+namespace cltune {
+// =================================================================================================
+
+// Max-length of strings
+constexpr auto kStringLength = 256;
+
+// =================================================================================================
+
+// Error occurred in the C++11 CUDA header (this file)
+inline void Error(const std::string &message) {
+  throw std::runtime_error("Internal CUDA error: "+message);
+}
+
+// Error occurred in the CUDA driver API
+inline void CheckError(const CUresult status) {
+  if (status != CUDA_SUCCESS) {
+    const char* status_code;
+    cuGetErrorName(status, &status_code);
+    const char* status_string;
+    cuGetErrorString(status, &status_string);
+    throw std::runtime_error("Internal CUDA error "+std::string{status_code}+
+                             " : "+std::string{status_string});
+  }
+}
+
+// Error occurred in the NVIDIA runtime compilation API
+inline void CheckError(const nvrtcResult status) {
+  if (status != NVRTC_SUCCESS) {
+    const char* status_string = nvrtcGetErrorString(status);
+    throw std::runtime_error("Internal CUDA error: "+std::string{status_string});
+  }
+}
+
+// =================================================================================================
+
+// C++11 version of two 'CUevent' pointers
+class Event {
+ public:
+  // Note that there is no constructor based on the regular CUDA data-type because of extra state
+
+  // Regular constructor with memory management
+  explicit Event():
+      start_(new CUevent, [](CUevent* e) { CheckError(cuEventDestroy(*e)); delete e; }),
+      end_(new CUevent, [](CUevent* e) { CheckError(cuEventDestroy(*e)); delete e; }) {
+    CheckError(cuEventCreate(start_.get(), CU_EVENT_DEFAULT));
+    CheckError(cuEventCreate(end_.get(), CU_EVENT_DEFAULT));
+  }
+
+  // Retrieves the elapsed time of the last recorded event
+  float GetElapsedTime() const {
+    auto result = 0.0f;
+    cuEventElapsedTime(&result, *start_, *end_);
+    return result;
+  }
+
+  // Accessors to the private data-members
+  const CUevent& start() const { return *start_; }
+  const CUevent& end() const { return *end_; }
+ private:
+  std::shared_ptr<CUevent> start_;
+  std::shared_ptr<CUevent> end_;
+};
+
+// =================================================================================================
+
+// The CUDA platform: initializes the CUDA driver API
+class Platform {
+ public:
+
+  // Initializes the platform. Note that the platform ID variable is not actually used for CUDA.
+  explicit Platform(const size_t platform_id):
+    platform_id_(platform_id) {
+    CheckError(cuInit(0));
+  }
+
+  // Returns the number of devices on this platform
+  size_t NumDevices() const {
+    auto result = 0;
+    CheckError(cuDeviceGetCount(&result));
+    return static_cast<size_t>(result);
+  }
+
+ private:
+  size_t platform_id_;
+};
+
+// =================================================================================================
+
+// C++11 version of 'CUdevice'
+class Device {
+ public:
+
+  // Constructor based on the regular CUDA data-type
+  explicit Device(const CUdevice device): device_(device) { }
+
+  // Initialization
+  explicit Device(const Platform &platform, const size_t device_id) {
+    auto num_devices = platform.NumDevices();
+    if (num_devices == 0) { Error("no devices found"); }
+    CheckError(cuDeviceGet(&device_, device_id % num_devices));
+  }
+
+  // Methods to retrieve device information
+  std::string Version() const {
+    auto result = 0;
+    CheckError(cuDriverGetVersion(&result));
+    return "CUDA driver "+std::to_string(result);
+  }
+  std::string Vendor() const { return "NVIDIA Corporation"; }
+  std::string Name() const {
+    auto result = std::string{};
+    result.resize(kStringLength);
+    CheckError(cuDeviceGetName(&result[0], result.size(), device_));
+    return result;
+  }
+  std::string Type() const { return "GPU"; }
+  size_t MaxWorkGroupSize() const {return GetInfo(CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK); }
+  size_t MaxWorkItemDimensions() const { return size_t{3}; }
+  std::vector<size_t> MaxWorkItemSizes() const {
+    return std::vector<size_t>{GetInfo(CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X),
+                               GetInfo(CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y),
+                               GetInfo(CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z)};
+  }
+  size_t LocalMemSize() const { return GetInfo(CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK); }
+  std::string Capabilities() const {
+    auto major = GetInfo(CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR);
+    auto minor = GetInfo(CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR);
+    return "SM "+std::to_string(major)+"."+std::to_string(minor);
+  }
+  size_t CoreClock() const { return 1e-3*GetInfo(CU_DEVICE_ATTRIBUTE_CLOCK_RATE); }
+  size_t ComputeUnits() const { return GetInfo(CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT); }
+  size_t MemorySize() const {
+    auto result = size_t{0};
+    CheckError(cuDeviceTotalMem(&result, device_));
+    return result;
+  }
+  size_t MaxAllocSize() const { return MemorySize(); }
+  size_t MemoryClock() const { return 1e-3*GetInfo(CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE); }
+  size_t MemoryBusWidth() const { return GetInfo(CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH); }
+
+  // Configuration-validity checks
+  bool IsLocalMemoryValid(const size_t local_mem_usage) const {
+    return (local_mem_usage <= LocalMemSize());
+  }
+  bool IsThreadConfigValid(const std::vector<size_t> &local) const {
+    auto local_size = size_t{1};
+    for (const auto &item: local) { local_size *= item; }
+    for (auto i=size_t{0}; i<local.size(); ++i) {
+      if (local[i] > MaxWorkItemSizes()[i]) { return false; }
+    }
+    if (local_size > MaxWorkGroupSize()) { return false; }
+    if (local.size() > MaxWorkItemDimensions()) { return false; }
+    return true;
+  }
+
+  // Accessor to the private data-member
+  const CUdevice& operator()() const { return device_; }
+ private:
+  CUdevice device_;
+
+  // Private helper function
+  size_t GetInfo(const CUdevice_attribute info) const {
+    auto result = 0;
+    CheckError(cuDeviceGetAttribute(&result, info, device_));
+    return static_cast<size_t>(result);
+  }
+};
+
+// =================================================================================================
+
+// C++11 version of 'CUcontext'
+class Context {
+ public:
+
+  // Constructor based on the regular CUDA data-type: memory management is handled elsewhere
+  explicit Context(const CUcontext context):
+      context_(new CUcontext) {
+    *context_ = context;
+  }
+
+  // Regular constructor with memory management
+  explicit Context(const Device &device):
+      context_(new CUcontext, [](CUcontext* c) { CheckError(cuCtxDestroy(*c)); delete c; }) {
+    CheckError(cuCtxCreate(context_.get(), 0, device()));
+  }
+
+  // Accessor to the private data-member
+  const CUcontext& operator()() const { return *context_; }
+ private:
+  std::shared_ptr<CUcontext> context_;
+};
+
+// =================================================================================================
+
+// Enumeration of build statuses of the run-time compilation process
+enum class BuildStatus { kSuccess, kError, kInvalid };
+
+// C++11 version of 'nvrtcProgram'. Additionally holds the program's source code.
+class Program {
+ public:
+  // Note that there is no constructor based on the regular CUDA data-type because of extra state
+
+  // Regular constructor with memory management
+  explicit Program(const Context &, std::string source):
+      program_(new nvrtcProgram, [](nvrtcProgram* p) { CheckError(nvrtcDestroyProgram(p));
+                                                       delete p; }),
+      source_(std::move(source)),
+      source_ptr_(&source_[0]) {
+    CheckError(nvrtcCreateProgram(program_.get(), source_ptr_, nullptr, 0, nullptr, nullptr));
+  }
+
+  // Compiles the device program and returns whether or not there where any warnings/errors
+  BuildStatus Build(const Device &, std::vector<std::string> &options) {
+    auto raw_options = std::vector<const char*>();
+    for (const auto &option: options) {
+      raw_options.push_back(option.c_str());
+    }
+    auto status = nvrtcCompileProgram(*program_, raw_options.size(), raw_options.data());
+    if (status == NVRTC_ERROR_COMPILATION) {
+      return BuildStatus::kError;
+    }
+    else if (status == NVRTC_ERROR_INVALID_PROGRAM) {
+      return BuildStatus::kInvalid;
+    }
+    else {
+      CheckError(status);
+      return BuildStatus::kSuccess;
+    }
+  }
+
+  // Retrieves the warning/error message from the compiler (if any)
+  std::string GetBuildInfo(const Device &) const {
+    auto bytes = size_t{0};
+    CheckError(nvrtcGetProgramLogSize(*program_, &bytes));
+    auto result = std::string{};
+    result.resize(bytes);
+    CheckError(nvrtcGetProgramLog(*program_, &result[0]));
+    return result;
+  }
+
+  // Retrieves an intermediate representation of the compiled program (i.e. PTX)
+  std::string GetIR() const {
+    auto bytes = size_t{0};
+    CheckError(nvrtcGetPTXSize(*program_, &bytes));
+    auto result = std::string{};
+    result.resize(bytes);
+    CheckError(nvrtcGetPTX(*program_, &result[0]));
+    return result;
+  }
+
+  // Accessor to the private data-member
+  const nvrtcProgram& operator()() const { return *program_; }
+ private:
+  std::shared_ptr<nvrtcProgram> program_;
+  std::string source_;
+  const char* source_ptr_;
+};
+
+// =================================================================================================
+
+// C++11 version of 'CUstream'
+class Queue {
+ public:
+  // Note that there is no constructor based on the regular CUDA data-type because of extra state
+
+  // Regular constructor with memory management
+  explicit Queue(const Context &context, const Device &device):
+      queue_(new CUstream, [](CUstream* s) { CheckError(cuStreamDestroy(*s)); delete s; }),
+      context_(context),
+      device_(device) {
+    CheckError(cuStreamCreate(queue_.get(), CU_STREAM_NON_BLOCKING));
+  }
+
+  // Synchronizes the queue and optionaly also an event
+  void Finish(Event &event) const {
+    CheckError(cuEventSynchronize(event.end()));
+    Finish();
+  }
+  void Finish() const {
+    CheckError(cuStreamSynchronize(*queue_));
+  }
+
+  // Retrieves the corresponding context or device
+  Context GetContext() const { return context_; }
+  Device GetDevice() const { return device_; }
+
+  // Accessor to the private data-member
+  const CUstream& operator()() const { return *queue_; }
+ private:
+  std::shared_ptr<CUstream> queue_;
+  const Context context_;
+  const Device device_;
+};
+
+// =================================================================================================
+
+// C++11 version of page-locked host memory
+template <typename T>
+class BufferHost {
+ public:
+
+  // Regular constructor with memory management
+  explicit BufferHost(const Context &, const size_t size):
+      buffer_(new void*, [](void** m) { CheckError(cuMemFreeHost(*m)); delete m; }),
+      size_(size) {
+    CheckError(cuMemAllocHost(buffer_.get(), size*sizeof(T)));
+  }
+
+  // Retrieves the actual allocated size in bytes
+  size_t GetSize() const {
+    return size_*sizeof(T);
+  }
+
+  // Compatibility with std::vector
+  size_t size() const { return size_; }
+  T* begin() { return &static_cast<T*>(*buffer_)[0]; }
+  T* end() { return &static_cast<T*>(*buffer_)[size_-1]; }
+  T& operator[](const size_t i) { return static_cast<T*>(*buffer_)[i]; }
+  T* data() { return static_cast<T*>(*buffer_); }
+  const T* data() const { return static_cast<T*>(*buffer_); }
+
+ private:
+  std::shared_ptr<void*> buffer_;
+  const size_t size_;
+};
+
+// =================================================================================================
+
+// Enumeration of buffer access types
+enum class BufferAccess { kReadOnly, kWriteOnly, kReadWrite, kNotOwned };
+
+// C++11 version of 'CUdeviceptr'
+template <typename T>
+class Buffer {
+ public:
+
+  // Constructor based on the regular CUDA data-type: memory management is handled elsewhere
+  explicit Buffer(const CUdeviceptr buffer):
+      buffer_(new CUdeviceptr),
+      access_(BufferAccess::kNotOwned) {
+    *buffer_ = buffer;
+  }
+
+  // Regular constructor with memory management. If this class does not own the buffer object, then
+  // the memory will not be freed automatically afterwards.
+  explicit Buffer(const Context &, const BufferAccess access, const size_t size):
+      buffer_(new CUdeviceptr, [access](CUdeviceptr* m) {
+        if (access != BufferAccess::kNotOwned) { CheckError(cuMemFree(*m)); }
+        delete m;
+      }),
+      access_(access) {
+    CheckError(cuMemAlloc(buffer_.get(), size*sizeof(T)));
+  }
+
+  // As above, but now with read/write access as a default
+  explicit Buffer(const Context &context, const size_t size):
+    Buffer<T>(context, BufferAccess::kReadWrite, size) {
+  }
+
+  // Constructs a new buffer based on an existing host-container
+  template <typename Iterator>
+  explicit Buffer(const Context &context, const Queue &queue, Iterator start, Iterator end):
+    Buffer(context, BufferAccess::kReadWrite, static_cast<size_t>(end - start)) {
+    auto size = static_cast<size_t>(end - start);
+    auto pointer = &*start;
+    CheckError(cuMemcpyHtoDAsync(*buffer_, pointer, size*sizeof(T), queue()));
+    queue.Finish();
+  }
+
+  // Copies from device to host: reading the device buffer a-synchronously
+  void ReadAsync(const Queue &queue, const size_t size, T* host, const size_t offset = 0) {
+    if (access_ == BufferAccess::kWriteOnly) { Error("reading from a write-only buffer"); }
+    CheckError(cuMemcpyDtoHAsync(host, *buffer_ + offset*sizeof(T), size*sizeof(T), queue()));
+  }
+  void ReadAsync(const Queue &queue, const size_t size, std::vector<T> &host,
+                 const size_t offset = 0) {
+    if (host.size() < size) { Error("target host buffer is too small"); }
+    ReadAsync(queue, size, host.data(), offset);
+  }
+  void ReadAsync(const Queue &queue, const size_t size, BufferHost<T> &host,
+                 const size_t offset = 0) {
+    if (host.size() < size) { Error("target host buffer is too small"); }
+    ReadAsync(queue, size, host.data(), offset);
+  }
+
+  // Copies from device to host: reading the device buffer
+  void Read(const Queue &queue, const size_t size, T* host, const size_t offset = 0) {
+    ReadAsync(queue, size, host, offset);
+    queue.Finish();
+  }
+  void Read(const Queue &queue, const size_t size, std::vector<T> &host, const size_t offset = 0) {
+    Read(queue, size, host.data(), offset);
+  }
+  void Read(const Queue &queue, const size_t size, BufferHost<T> &host, const size_t offset = 0) {
+    Read(queue, size, host.data(), offset);
+  }
+
+  // Copies from host to device: writing the device buffer a-synchronously
+  void WriteAsync(const Queue &queue, const size_t size, const T* host, const size_t offset = 0) {
+    if (access_ == BufferAccess::kReadOnly) { Error("writing to a read-only buffer"); }
+    if (GetSize() < (offset+size)*sizeof(T)) { Error("target device buffer is too small"); }
+    CheckError(cuMemcpyHtoDAsync(*buffer_ + offset*sizeof(T), host, size*sizeof(T), queue()));
+  }
+  void WriteAsync(const Queue &queue, const size_t size, const std::vector<T> &host,
+                  const size_t offset = 0) {
+    WriteAsync(queue, size, host.data(), offset);
+  }
+  void WriteAsync(const Queue &queue, const size_t size, const BufferHost<T> &host,
+                  const size_t offset = 0) {
+    WriteAsync(queue, size, host.data(), offset);
+  }
+
+  // Copies from host to device: writing the device buffer 
+  void Write(const Queue &queue, const size_t size, const T* host, const size_t offset = 0) {
+    WriteAsync(queue, size, host, offset);
+    queue.Finish();
+  }
+  void Write(const Queue &queue, const size_t size, const std::vector<T> &host,
+             const size_t offset = 0) {
+    Write(queue, size, host.data(), offset);
+  }
+  void Write(const Queue &queue, const size_t size, const BufferHost<T> &host,
+             const size_t offset = 0) {
+    Write(queue, size, host.data(), offset);
+  }
+
+  // Copies the contents of this buffer into another device buffer
+  void CopyToAsync(const Queue &queue, const size_t size, const Buffer<T> &destination) const {
+    CheckError(cuMemcpyDtoDAsync(destination(), *buffer_, size*sizeof(T), queue()));
+  }
+  void CopyTo(const Queue &queue, const size_t size, const Buffer<T> &destination) const {
+    CopyToAsync(queue, size, destination);
+    queue.Finish();
+  }
+
+  // Retrieves the actual allocated size in bytes
+  size_t GetSize() const {
+    auto result = size_t{0};
+    CheckError(cuMemGetAddressRange(nullptr, &result, *buffer_));
+    return result;
+  }
+
+  // Accessors to the private data-members
+  CUdeviceptr operator()() const { return *buffer_; }
+  CUdeviceptr& operator()() { return *buffer_; }
+ private:
+  std::shared_ptr<CUdeviceptr> buffer_;
+  const BufferAccess access_;
+};
+
+// =================================================================================================
+
+// C++11 version of 'CUfunction'
+class Kernel {
+ public:
+
+  // Constructor based on the regular CUDA data-type: memory management is handled elsewhere
+  explicit Kernel(const CUmodule module, const CUfunction kernel):
+    module_(module),
+    kernel_(kernel) {
+  }
+
+  // Regular constructor with memory management
+  explicit Kernel(const Program &program, const std::string &name) {
+    CheckError(cuModuleLoadDataEx(&module_, program.GetIR().data(), 0, nullptr, nullptr));
+    CheckError(cuModuleGetFunction(&kernel_, module_, name.c_str()));
+  }
+
+  // Sets a kernel argument at the indicated position. This stores both the value of the argument
+  // (as raw bytes) and the index indicating where this value can be found.
+  template <typename T>
+  void SetArgument(const size_t index, const T &value) {
+    if (index >= arguments_indices_.size()) { arguments_indices_.resize(index+1); }
+    arguments_indices_[index] = arguments_data_.size();
+    for (auto j=size_t(0); j<sizeof(T); ++j) {
+      arguments_data_.push_back(reinterpret_cast<const char*>(&value)[j]);
+    }
+  }
+  template <typename T>
+  void SetArgument(const size_t index, Buffer<T> &value) {
+    SetArgument(index, value());
+  }
+
+  // Sets all arguments in one go using parameter packs. Note that this resets all previously set
+  // arguments using 'SetArgument' or 'SetArguments'.
+  template <typename... Args>
+  void SetArguments(Args&... args) {
+    arguments_indices_.clear();
+    arguments_data_.clear();
+    SetArgumentsRecursive(0, args...);
+  }
+
+  // Retrieves the amount of local memory used per work-group for this kernel. Note that this the
+  // shared memory in CUDA terminology.
+  size_t LocalMemUsage(const Device &) const {
+    auto result = 0;
+    CheckError(cuFuncGetAttribute(&result, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, kernel_));
+    return static_cast<size_t>(result);
+  }
+
+  // Launches a kernel onto the specified queue
+  void Launch(const Queue &queue, const std::vector<size_t> &global,
+              const std::vector<size_t> &local, Event &event) {
+
+    // Creates the grid (number of threadblocks) and sets the block sizes (threads per block)
+    auto grid = std::vector<size_t>{1, 1, 1};
+    auto block = std::vector<size_t>{1, 1, 1};
+    if (global.size() != local.size()) { Error("invalid thread/workgroup dimensions"); }
+    for (auto i=size_t{0}; i<local.size(); ++i) { grid[i] = global[i]/local[i]; }
+    for (auto i=size_t{0}; i<local.size(); ++i) { block[i] = local[i]; }
+
+    // Creates the array of pointers from the arrays of indices & data
+    std::vector<void*> pointers;
+    for (auto &index: arguments_indices_) {
+      pointers.push_back(&arguments_data_[index]);
+    }
+
+    // Launches the kernel, its execution time is recorded by events
+    CheckError(cuEventRecord(event.start(), queue()));
+    CheckError(cuLaunchKernel(kernel_, grid[0], grid[1], grid[2], block[0], block[1], block[2],
+                              0, queue(), pointers.data(), nullptr));
+    CheckError(cuEventRecord(event.end(), queue()));
+  }
+
+  // As above, but with the default local workgroup size
+  // TODO: Implement this function
+  void Launch(const Queue &, const std::vector<size_t> &, Event &) {
+    Error("launching with a default workgroup size is not implemented for the CUDA back-end");
+  }
+
+  // Accessors to the private data-members
+  const CUfunction& operator()() const { return kernel_; }
+  CUfunction operator()() { return kernel_; }
+ private:
+  CUmodule module_;
+  CUfunction kernel_;
+  std::vector<size_t> arguments_indices_; // Indices of the arguments
+  std::vector<char> arguments_data_; // The arguments data as raw bytes
+
+  // Internal implementation for the recursive SetArguments function.
+  template <typename T>
+  void SetArgumentsRecursive(const size_t index, T &first) {
+    SetArgument(index, first);
+  }
+  template <typename T, typename... Args>
+  void SetArgumentsRecursive(const size_t index, T &first, Args&... args) {
+    SetArgument(index, first);
+    SetArgumentsRecursive(index+1, args...);
+  }
+};
+
+// =================================================================================================
+} // namespace cltune
+
+// CLTUNE_CUPP11_H_
+#endif

--- a/include/internal/kernel_info.h
+++ b/include/internal/kernel_info.h
@@ -37,7 +37,12 @@
 #include <stdexcept>
 #include <memory>
 
-#include "internal/clpp11.h"
+// Uses either the OpenCL or CUDA back-end (CLCudaAPI C++11 headers)
+#if USE_OPENCL
+  #include "internal/clpp11.h"
+#else
+  #include "internal/cupp11.h"
+#endif
 
 #include "cltune.h"
 
@@ -94,7 +99,7 @@ class KernelInfo {
     Exception(const std::string &message): std::runtime_error(message) { }
   };
 
-  // Initializes the class with a given name and a string of OpenCL source-code
+  // Initializes the class with a given name and a string of kernel source-code
   explicit KernelInfo(const std::string name, const std::string source, const Device &device);
 
   // Accessors (getters)
@@ -159,7 +164,6 @@ class KernelInfo {
   std::vector<Constraint> constraints_;
   LocalMemory local_memory_;
 
-  // OpenCL device
   Device device_;
 
   // Global/local thread-sizes

--- a/include/internal/tuner_impl.h
+++ b/include/internal/tuner_impl.h
@@ -49,6 +49,9 @@ namespace cltune {
 using float2 = std::complex<float>; // cl_float2;
 using double2 = std::complex<double>; // cl_double2;
 
+// Raw device buffer
+using BufferRaw = cl_mem;
+
 // Enumeration of currently supported data-types by this class
 enum class MemType { kInt, kSizeT, kFloat, kDouble, kFloat2, kDouble2 };
 
@@ -77,7 +80,7 @@ class TunerImpl {
     size_t index;       // The OpenCL kernel-argument index
     size_t size;        // The number of elements (not bytes)
     MemType type;       // The data-type (e.g. float)
-    Buffer buffer;      // The OpenCL buffer on the device
+    BufferRaw buffer;   // The buffer on the device
   };
 
   // Helper structure to hold the results of a tuning run

--- a/include/internal/tuner_impl.h
+++ b/include/internal/tuner_impl.h
@@ -32,7 +32,12 @@
 #ifndef CLTUNE_TUNER_IMPL_H_
 #define CLTUNE_TUNER_IMPL_H_
 
-#include "internal/clpp11.h" // For OpenCL C++11 wrappers
+// Uses either the OpenCL or CUDA back-end (CLCudaAPI C++11 headers)
+#if USE_OPENCL
+  #include "internal/clpp11.h"
+#else
+  #include "internal/cupp11.h"
+#endif
 
 #include "internal/kernel_info.h"
 
@@ -50,7 +55,11 @@ using float2 = std::complex<float>; // cl_float2;
 using double2 = std::complex<double>; // cl_double2;
 
 // Raw device buffer
-using BufferRaw = cl_mem;
+#if USE_OPENCL
+  using BufferRaw = cl_mem;
+#else
+  using BufferRaw = CUdeviceptr;
+#endif
 
 // Enumeration of currently supported data-types by this class
 enum class MemType { kInt, kSizeT, kFloat, kDouble, kFloat2, kDouble2 };
@@ -75,9 +84,9 @@ class TunerImpl {
   static const std::string kMessageResult;
   static const std::string kMessageBest;
 
-  // Helper structure to store an OpenCL memory argument for a kernel
+  // Helper structure to store a device memory argument for a kernel
   struct MemArgument {
-    size_t index;       // The OpenCL kernel-argument index
+    size_t index;       // The kernel-argument index
     size_t size;        // The number of elements (not bytes)
     MemType type;       // The data-type (e.g. float)
     BufferRaw buffer;   // The buffer on the device
@@ -104,7 +113,7 @@ class TunerImpl {
   TunerResult RunKernel(const std::string &source, const KernelInfo &kernel,
                         const size_t configuration_id, const size_t num_configurations);
 
-  // Sets an OpenCL buffer to zero
+  // Sets a device buffer to zero
   template <typename T> void ResetMemArgument(MemArgument &argument);
 
   // Stores the output of the reference run into the host memory
@@ -133,12 +142,12 @@ class TunerImpl {
   // argument. Supports all enumerations of MemType.
   template <typename T> MemType GetType();
 
-  // Accessors to OpenCL data-types
+  // Accessors to device data-types
   const Device device() const { return device_; }
   const Context context() const { return context_; }
   Queue queue() const { return queue_; }
 
-  // OpenCL variables
+  // Device variables
   Platform platform_;
   Device device_;
   Context context_;

--- a/samples/cl_to_cuda.h
+++ b/samples/cl_to_cuda.h
@@ -13,9 +13,10 @@
 // Replaces the OpenCL keywords with CUDA equivalent
 #define __kernel __placeholder__
 #define __global 
-#define __placeholder__ __global__
+#define __placeholder__ extern "C" __global__
 #define __local __shared__
 #define restrict __restrict__
+#define __constant const
 
 // Replaces OpenCL synchronisation with CUDA synchronisation
 #define barrier(x) __syncthreads()
@@ -31,8 +32,12 @@ __device__ int get_global_id(int x) {
     return (x == 0) ? blockIdx.x*blockDim.x + threadIdx.x : blockIdx.y*blockDim.y + threadIdx.y;
 }
 
-// Adds the float8 data-type which is not available natively under CUDA
+// Adds the data-types which are not available natively under CUDA
 typedef struct { float s0; float s1; float s2; float s3;
                  float s4; float s5; float s6; float s7; } float8;
+typedef struct { float s0; float s1; float s2; float s3;
+                 float s4; float s5; float s6; float s7;
+                 float s8; float s9; float s10; float s11;
+                 float s12; float s13; float s14; float s15; } float16;
 
 // =================================================================================================

--- a/samples/cl_to_cuda.h
+++ b/samples/cl_to_cuda.h
@@ -1,0 +1,38 @@
+
+// =================================================================================================
+// This file is part of the CLTune project, which loosely follows the Google C++ styleguide and uses
+// a tab-size of two spaces and a max-width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file contains an (incomplete) header to interpret OpenCL kernels as CUDA kernels.
+//
+// =================================================================================================
+
+// Replaces the OpenCL keywords with CUDA equivalent
+#define __kernel __placeholder__
+#define __global 
+#define __placeholder__ __global__
+#define __local __shared__
+#define restrict __restrict__
+
+// Replaces OpenCL synchronisation with CUDA synchronisation
+#define barrier(x) __syncthreads()
+
+// Replaces the OpenCL get_xxx_ID with CUDA equivalents
+__device__ int get_local_id(int x) {
+    return (x == 0) ? threadIdx.x : threadIdx.y;
+}
+__device__ int get_group_id(int x) {
+    return (x == 0) ? blockIdx.x : blockIdx.y;
+}
+__device__ int get_global_id(int x) {
+    return (x == 0) ? blockIdx.x*blockDim.x + threadIdx.x : blockIdx.y*blockDim.y + threadIdx.y;
+}
+
+// Adds the float8 data-type which is not available natively under CUDA
+typedef struct { float s0; float s1; float s2; float s3;
+                 float s4; float s5; float s6; float s7; } float8;
+
+// =================================================================================================

--- a/samples/conv/conv.cc
+++ b/samples/conv/conv.cc
@@ -62,6 +62,14 @@ constexpr auto kSizeY = size_t{4096}; // Matrix dimension Y
 // Example showing how to tune an OpenCL 2D convolution kernel
 int main(int argc, char* argv[]) {
 
+  // Sets the filenames of the OpenCL kernels (optionally automatically translated to CUDA)
+  auto conv = std::vector<std::string>{"../samples/conv/conv.opencl"};
+  auto conv_reference = std::vector<std::string>{"../samples/conv/conv_reference.opencl"};
+  #ifndef USE_OPENCL
+    conv.insert(conv.begin(), "../samples/cl_to_cuda.h");
+    conv_reference.insert(conv_reference.begin(), "../samples/cl_to_cuda.h");
+  #endif
+
   // Selects the device, the search method and its first parameter. These parameters are all
   // optional and are thus also given default values.
   auto device_id = kDefaultDevice;
@@ -127,7 +135,7 @@ int main(int argc, char* argv[]) {
   // ===============================================================================================
 
   // Adds a heavily tuneable kernel and some example parameter values
-  auto id = tuner.AddKernel({"../samples/conv/conv.opencl"}, "conv", {kSizeX, kSizeY}, {1, 1});
+  auto id = tuner.AddKernel(conv, "conv", {kSizeX, kSizeY}, {1, 1});
   tuner.AddParameter(id, "TBX", {8, 16, 32, 64});
   tuner.AddParameter(id, "TBY", {8, 16, 32, 64});
   tuner.AddParameter(id, "LOCAL", {0, 1, 2});
@@ -189,7 +197,7 @@ int main(int argc, char* argv[]) {
   // Sets the tuner's golden reference function. This kernel contains the reference code to which
   // the output is compared. Supplying such a function is not required, but it is necessary for
   // correctness checks to be enabled.
-  tuner.SetReference({"../samples/conv/conv_reference.opencl"}, "conv_reference", {kSizeX, kSizeY}, {8,8});
+  tuner.SetReference(conv_reference, "conv_reference", {kSizeX, kSizeY}, {8,8});
 
   // Sets the function's arguments. Note that all kernels have to accept (but not necessarily use)
   // all input arguments.

--- a/samples/gemm/gemm.cc
+++ b/samples/gemm/gemm.cc
@@ -60,6 +60,14 @@ constexpr auto kSizeK = size_t{2048};
 // matrix B is pre-transposed, alpha equals 1 and beta equals 0: C = A * B^T
 int main(int argc, char* argv[]) {
 
+  // Sets the filenames of the OpenCL kernels (optionally automatically translated to CUDA)
+  auto gemm_fast = std::vector<std::string>{"../samples/gemm/gemm.opencl"};
+  auto gemm_reference = std::vector<std::string>{"../samples/gemm/gemm_reference.opencl"};
+  #ifndef USE_OPENCL
+    gemm_fast.insert(gemm_fast.begin(), "../samples/cl_to_cuda.h");
+    gemm_reference.insert(gemm_reference.begin(), "../samples/cl_to_cuda.h");
+  #endif
+
   // Selects the device, the search method and its first parameter. These parameters are all
   // optional and are thus also given default values.
   auto device_id = kDefaultDevice;
@@ -111,7 +119,7 @@ int main(int argc, char* argv[]) {
 
   // Adds a heavily tuneable kernel and some example parameter values. Others can be added, but for
   // this example this already leads to plenty of kernels to test.
-  auto id = tuner.AddKernel({"../samples/gemm/gemm.opencl"}, "gemm_fast", {kSizeM, kSizeN}, {1, 1});
+  auto id = tuner.AddKernel(gemm_fast, "gemm_fast", {kSizeM, kSizeN}, {1, 1});
   tuner.AddParameter(id, "MWG", {16, 32, 64, 128});
   tuner.AddParameter(id, "NWG", {16, 32, 64, 128});
   tuner.AddParameter(id, "KWG", {16, 32});
@@ -170,7 +178,7 @@ int main(int argc, char* argv[]) {
   // Sets the tuner's golden reference function. This kernel contains the reference code to which
   // the output is compared. Supplying such a function is not required, but it is necessarily for
   // correctness checks to be enabled.
-  tuner.SetReference({"../samples/gemm/gemm_reference.opencl"}, "gemm_reference", {kSizeM, kSizeN}, {8,8});
+  tuner.SetReference(gemm_reference, "gemm_reference", {kSizeM, kSizeN}, {8,8});
 
   // Sets the function's arguments. Note that all kernels have to accept (but not necessarily use)
   // all input arguments.

--- a/samples/simple/simple.cc
+++ b/samples/simple/simple.cc
@@ -39,6 +39,16 @@
 // local memory.
 int main() {
 
+  // Sets the filenames of the OpenCL kernels (optionally automatically translated to CUDA)
+  auto matvec_unroll = std::vector<std::string>{"../samples/simple/simple_unroll.opencl"};
+  auto matvec_tiled = std::vector<std::string>{"../samples/simple/simple_tiled.opencl"};
+  auto matvec_reference = std::vector<std::string>{"../samples/simple/simple_reference.opencl"};
+  #ifndef USE_OPENCL
+    matvec_unroll.insert(matvec_unroll.begin(), "../samples/cl_to_cuda.h");
+    matvec_tiled.insert(matvec_tiled.begin(), "../samples/cl_to_cuda.h");
+    matvec_reference.insert(matvec_reference.begin(), "../samples/cl_to_cuda.h");
+  #endif
+
   // Matrix size
   constexpr auto kSizeM = 2048;
   constexpr auto kSizeN = 4096;
@@ -64,20 +74,20 @@ int main() {
   // Adds a kernel which supports unrolling through the UNROLL parameter. Note that the kernel
   // itself needs to implement the UNROLL parameter and (in this case) only accepts a limited
   // amount of values.
-  auto id = tuner.AddKernel({"../samples/simple/simple_unroll.opencl"}, "matvec_unroll", {kSizeM}, {128});
+  auto id = tuner.AddKernel(matvec_unroll, "matvec_unroll", {kSizeM}, {128});
   tuner.AddParameter(id, "UNROLL", {1, 2, 4});
 
   // Adds another kernel and its parameters. This kernel caches the input vector X into local
   // memory to save global memory accesses. Note that the kernel's workgroup size is determined by
   // the tile size parameter TS.
-  id = tuner.AddKernel({"../samples/simple/simple_tiled.opencl"}, "matvec_tiled", {kSizeM}, {1});
+  id = tuner.AddKernel(matvec_tiled, "matvec_tiled", {kSizeM}, {1});
   tuner.AddParameter(id, "TS", {32, 64, 128, 256, 512});
   tuner.MulLocalSize(id, {"TS"});
 
   // Sets the tuner's golden reference function. This kernel contains the reference code to which
   // the output is compared. Supplying such a function is not required, but it is necessarily for
   // correctness checks to be enabled.
-  tuner.SetReference({"../samples/simple/simple_reference.opencl"}, "matvec_reference", {kSizeM}, {128});
+  tuner.SetReference(matvec_reference, "matvec_reference", {kSizeM}, {128});
 
   // Sets the function's arguments. Note that all kernels have to accept (but not necessarily use)
   // all input arguments.

--- a/src/cltune.cc
+++ b/src/cltune.cc
@@ -49,7 +49,7 @@ Tuner::~Tuner() {
 
 // =================================================================================================
 
-// Loads the OpenCL source-code from a file and calls the function-overload below.
+// Loads the kernel source-code from a file and calls the function-overload below.
 size_t Tuner::AddKernel(const std::vector<std::string> &filenames, const std::string &kernel_name,
                         const IntRange &global, const IntRange &local) {
   auto source = std::string{};
@@ -59,7 +59,7 @@ size_t Tuner::AddKernel(const std::vector<std::string> &filenames, const std::st
   return AddKernelFromString(source, kernel_name, global, local);
 }
 
-// Loads the OpenCL source-code from a string and creates a new variable of type KernelInfo to store
+// Loads the kernel source-code from a string and creates a new variable of type KernelInfo to store
 // all the kernel-information.
 size_t Tuner::AddKernelFromString(const std::string &source, const std::string &kernel_name,
                                   const IntRange &global, const IntRange &local) {

--- a/src/cltune.cc
+++ b/src/cltune.cc
@@ -162,10 +162,10 @@ void Tuner::SetLocalMemoryUsage(const size_t id, LocalMemoryFunction amount,
 // vector of data. Then, upload it to the device and store the argument in a list.
 template <typename T>
 void Tuner::AddArgumentInput(const std::vector<T> &source) {
-  auto device_buffer = Buffer(pimpl->context(), source.size()*sizeof(T));
-  device_buffer.Write(pimpl->queue(), source.size()*sizeof(T), source);
+  auto device_buffer = Buffer<T>(pimpl->context(), BufferAccess::kNotOwned, source.size());
+  device_buffer.Write(pimpl->queue(), source.size(), source);
   auto argument = TunerImpl::MemArgument{pimpl->argument_counter_++, source.size(),
-                                         pimpl->GetType<T>(), device_buffer};
+                                         pimpl->GetType<T>(), device_buffer()};
   pimpl->arguments_input_.push_back(argument);
 }
 
@@ -181,9 +181,9 @@ template void Tuner::AddArgumentInput<double2>(const std::vector<double2>&);
 // sense that they will be checked in the verification process.
 template <typename T>
 void Tuner::AddArgumentOutput(const std::vector<T> &source) {
-  auto device_buffer = Buffer(pimpl->context(), source.size()*sizeof(T));
+  auto device_buffer = Buffer<T>(pimpl->context(), BufferAccess::kNotOwned, source.size());
   auto argument = TunerImpl::MemArgument{pimpl->argument_counter_++, source.size(),
-                                         pimpl->GetType<T>(), device_buffer};
+                                         pimpl->GetType<T>(), device_buffer()};
   pimpl->arguments_output_.push_back(argument);
 }
 

--- a/src/kernel_info.cc
+++ b/src/kernel_info.cc
@@ -33,7 +33,7 @@
 namespace cltune {
 // =================================================================================================
 
-// Initializes the name and OpenCL source-code, creates empty containers for all other member
+// Initializes the name and kernel source-code, creates empty containers for all other member
 // variables.
 KernelInfo::KernelInfo(const std::string name, const std::string source, const Device &device):
   name_(name),

--- a/src/ml_models/neural_network.cc
+++ b/src/ml_models/neural_network.cc
@@ -32,6 +32,7 @@
 #include <cmath>
 #include <random>
 #include <exception>
+#include <chrono>
 
 namespace cltune {
 // =================================================================================================


### PR DESCRIPTION
- Now using version 4.0 of the ```CLCudaAPI``` C++11 header (previously ```Claduc```)
- Added experimental support for CUDA kernels (thanks to the new headers)
- Made the ```simple``` example also work using CUDA
- Various minor fixes
