### PR TITLE
Add command line parameter for platform index to conv and gemm samples in line with description in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Several examples are included as part of the CLTune distribution. They illustrat
 * `gemm.cc` providing an advanced and heavily tunable implementation of matrix-matrix multiplication (GEMM)
 * `conv.cc` providing an advanced and heavily tunable implementation of 2D convolution
 
-The latter two optionally take command-line arguments. The first argument is an integer for the device to run on, the second argument is an integer to select a search strategy (0=random, 1=annealing, 2=PSO, 3=fullsearch), and the third an optional search-strategy parameter.
+The latter two optionally take command-line arguments. The first argument is an integer to select the platform (NVIDIA, AMD, etc.), the second argument is an integer for the device to run on, the third argument is an integer to select a search strategy (0=random, 1=annealing, 2=PSO, 3=fullsearch), and the fourth an optional search-strategy parameter.
 
 
 Search strategies and machine-learning

--- a/samples/conv/conv.cc
+++ b/samples/conv/conv.cc
@@ -78,9 +78,9 @@ int main(int argc, char* argv[]) {
   auto method = kDefaultSearchMethod;
   auto search_param_1 = kDefaultSearchParameter1;
   if (argc >= 2) {
-    device_id = static_cast<size_t>(std::stoi(std::string{argv[1]}));
+    platform_id = static_cast<size_t>(std::stoi(std::string{argv[1]}));
 	if (argc >= 3) {
-	  platform_id = static_cast<size_t>(std::stoi(std::string{argv[2]}));
+	  device_id = static_cast<size_t>(std::stoi(std::string{argv[2]}));
       if (argc >= 4) {
         method = static_cast<size_t>(std::stoi(std::string{argv[3]}));
         if (argc >= 5) {

--- a/samples/conv/conv.cc
+++ b/samples/conv/conv.cc
@@ -46,6 +46,7 @@ bool IsMultiple(size_t a, size_t b) {
 
 // Constants
 constexpr auto kDefaultDevice = size_t{0};
+constexpr auto kDefaultPlatform = size_t{0};
 constexpr auto kDefaultSearchMethod = size_t{1};
 constexpr auto kDefaultSearchParameter1 = size_t{4};
 
@@ -73,16 +74,20 @@ int main(int argc, char* argv[]) {
   // Selects the device, the search method and its first parameter. These parameters are all
   // optional and are thus also given default values.
   auto device_id = kDefaultDevice;
+  auto platform_id = kDefaultPlatform;
   auto method = kDefaultSearchMethod;
   auto search_param_1 = kDefaultSearchParameter1;
   if (argc >= 2) {
     device_id = static_cast<size_t>(std::stoi(std::string{argv[1]}));
-    if (argc >= 3) {
-      method = static_cast<size_t>(std::stoi(std::string{argv[2]}));
+	if (argc >= 3) {
+	  platform_id = static_cast<size_t>(std::stoi(std::string{argv[2]}));
       if (argc >= 4) {
-        search_param_1 = static_cast<size_t>(std::stoi(std::string{argv[3]}));
+        method = static_cast<size_t>(std::stoi(std::string{argv[3]}));
+        if (argc >= 5) {
+          search_param_1 = static_cast<size_t>(std::stoi(std::string{argv[4]}));
+        }
       }
-    }
+	}
   }
 
   // Creates data structures
@@ -115,8 +120,8 @@ int main(int argc, char* argv[]) {
 
   // ===============================================================================================
 
-  // Initializes the tuner (platform 0, device 'device_id')
-  cltune::Tuner tuner(size_t{0}, static_cast<size_t>(device_id));
+  // Initializes the tuner (platform 'platform_id', device 'device_id')
+  cltune::Tuner tuner(static_cast<size_t>(platform_id), static_cast<size_t>(device_id));
 
   // Sets one of the following search methods:
   // 0) Random search

--- a/samples/gemm/gemm.cc
+++ b/samples/gemm/gemm.cc
@@ -76,9 +76,9 @@ int main(int argc, char* argv[]) {
   auto method = kDefaultSearchMethod;
   auto search_param_1 = kDefaultSearchParameter1;
   if (argc >= 2) {
-    device_id = static_cast<size_t>(std::stoi(std::string{argv[1]}));
+    platform_id = static_cast<size_t>(std::stoi(std::string{argv[1]}));
 	if (argc >= 3) {
-	  platform_id = static_cast<size_t>(std::stoi(std::string{argv[2]}));
+      device_id = static_cast<size_t>(std::stoi(std::string{argv[2]}));
       if (argc >= 4) {
         method = static_cast<size_t>(std::stoi(std::string{argv[3]}));
         if (argc >= 5) {

--- a/samples/gemm/gemm.cc
+++ b/samples/gemm/gemm.cc
@@ -46,6 +46,7 @@ bool IsMultiple(size_t a, size_t b) {
 
 // Constants
 constexpr auto kDefaultDevice = size_t{0};
+constexpr auto kDefaultPlatform = size_t{0};
 constexpr auto kDefaultSearchMethod = size_t{1};
 constexpr auto kDefaultSearchParameter1 = size_t{4};
 
@@ -71,16 +72,20 @@ int main(int argc, char* argv[]) {
   // Selects the device, the search method and its first parameter. These parameters are all
   // optional and are thus also given default values.
   auto device_id = kDefaultDevice;
+  auto platform_id = kDefaultPlatform;
   auto method = kDefaultSearchMethod;
   auto search_param_1 = kDefaultSearchParameter1;
   if (argc >= 2) {
     device_id = static_cast<size_t>(std::stoi(std::string{argv[1]}));
-    if (argc >= 3) {
-      method = static_cast<size_t>(std::stoi(std::string{argv[2]}));
+	if (argc >= 3) {
+	  platform_id = static_cast<size_t>(std::stoi(std::string{argv[2]}));
       if (argc >= 4) {
-        search_param_1 = static_cast<size_t>(std::stoi(std::string{argv[3]}));
+        method = static_cast<size_t>(std::stoi(std::string{argv[3]}));
+        if (argc >= 5) {
+          search_param_1 = static_cast<size_t>(std::stoi(std::string{argv[4]}));
+        }
       }
-    }
+	}
   }
 
   // Creates input matrices
@@ -99,7 +104,7 @@ int main(int argc, char* argv[]) {
   for (auto &item: mat_c) { item = 0.0f; }
 
   // Initializes the tuner (platform 0, device 'device_id')
-  cltune::Tuner tuner(size_t{0}, static_cast<size_t>(device_id));
+  cltune::Tuner tuner(static_cast<size_t>(platform_id), static_cast<size_t>(device_id));
 
   // Sets one of the following search methods:
   // 0) Random search


### PR DESCRIPTION
This fixes the disagreement between the README and the samples that I identified in #34 and adds some improvements: I've changed the conv and gemm demos so that they do actually accept the platform index in addition to the device index. I've updated the README so that the description of the command line parameters given in the section ``Other examples'' does not conflict with that given at the end of the ``Development and tests'' section.