### PR TITLE
2D convolution sample - fix correctness and redundant loads

### DIFF
--- a/samples/conv/conv.cc
+++ b/samples/conv/conv.cc
@@ -91,9 +91,8 @@ int main(int argc, char* argv[]) {
   }
 
   // Creates data structures
-  const auto kExtraSize = size_t{FS*8};
-  auto mat_a = std::vector<float>((kExtraSize+kSizeX)*(kExtraSize+kSizeY));
-  auto mat_b = std::vector<float>(kSizeX*kSizeY);
+  auto mat_a = std::vector<float>((kSizeX+2*HFS)*(kSizeY+2*HFS), 0.0f);
+  auto mat_b = std::vector<float>(kSizeX*kSizeY, 0.0f);
   auto coeff = std::vector<float>(FS*FS);
 
   // Create a random number generator
@@ -101,9 +100,10 @@ int main(int argc, char* argv[]) {
   std::default_random_engine generator(static_cast<unsigned int>(random_seed));
   std::uniform_real_distribution<float> distribution(-2.0f, 2.0f);
 
-  // Populates input data structures
-  for (auto &item: mat_a) { item = distribution(generator); }
-  for (auto &item: mat_b) { item = 0.0f; }
+  // Populates input data structure by padded data
+  for (size_t i = 0; i < kSizeY; i++)
+    for (size_t j = 0; j < kSizeX; j++)
+      mat_a[(i + HFS) * (kSizeX + 2 * HFS) + j + HFS] = distribution(generator);
 
   // Creates the filter coefficients (gaussian blur)
   auto sigma = 1.0f;

--- a/samples/conv/conv.opencl
+++ b/samples/conv/conv.opencl
@@ -285,7 +285,7 @@ __kernel void conv(const int goff, const int dummy,
   InitAccRegisters(acc);
 
   // Accumulates in global memory
-  AccumulateGlobal(src, goff, coeff, acc, gid_x, gid_y);
+  AccumulateGlobal(src, goff+2*HFS, coeff, acc, gid_x, gid_y);
 
   // Computes and stores the result
   StoreResult(dest, goff, acc, gid_x, gid_y);
@@ -313,7 +313,7 @@ __kernel void conv(const int goff, const int dummy,
   const int loff = TBX*WPTX + 2*HFS + PADDING;
 
   // Caches data into local memory
-  LoadLocalPlusHalo(lmem, loff, src, goff, gid_x, gid_y, lid_x, lid_y);
+  LoadLocalPlusHalo(lmem, loff, src, goff+2*HFS, gid_x, gid_y, lid_x, lid_y);
 
   // Synchronizes all threads in a workgroup
   barrier(CLK_LOCAL_MEM_FENCE);
@@ -351,7 +351,7 @@ __kernel void conv(const int goff, const int dummy,
   const int loff = TBX*WPTX + 2*HFS + PADDING;
 
   // Caches data into local memory
-  LoadLocalFull(lmem, loff, src, goff, gid_x, gid_y, lid_x, lid_y);
+  LoadLocalFull(lmem, loff, src, goff+2*HFS, gid_x, gid_y, lid_x, lid_y);
 
   // Synchronizes all threads in a workgroup
   barrier(CLK_LOCAL_MEM_FENCE);

--- a/samples/conv/conv.opencl
+++ b/samples/conv/conv.opencl
@@ -129,9 +129,9 @@ inline void LoadLocalPlusHalo(__local float *lmem, const int loff,
 
       // Computes the conditionals
       const bool xst = lx < HFS;
-      const bool xlt = lx >= TBX-HFS;
+      const bool xlt = lx >= TBX*WPTX-HFS;
       const bool yst = ly < HFS;
-      const bool ylt = ly >= TBY-HFS;
+      const bool ylt = ly >= TBY*WPTY-HFS;
 
       // In the centre
                         lmem[(ly+1*HFS)*loff + (lx+1*HFS)] = src[(gy+1*HFS)*goff + (gx+1*HFS)];

--- a/samples/conv/conv_reference.opencl
+++ b/samples/conv/conv_reference.opencl
@@ -55,7 +55,7 @@ __kernel void conv_reference(const int size_x, const int size_y,
 
       // Performs the accumulation
       float coefficient = coeff[(fy+HFS)*FS + (fx+HFS)];
-      acc += coefficient * src[index_y*size_x + index_x];
+      acc += coefficient * src[index_y*(size_x+2*HFS) + index_x];
     }
   }
 


### PR DESCRIPTION
Hi, for my master's thesis, I am working on a 3D convolution kernel for KTT based on the 2D example from CLTune, and I found some parts that are incorrect.

1. There was no reason for `kExtraSize` to be `8*FS`, as the input matrix should be padded only `HFS` from every side.
2. The initialization of input matrix didn't pad it by zeros, I changed that. ... Now I think it may have been that way on purpose, let me know whether to change the initialization back.
3. As the input matrix is `kSizeX+2*HFS` wide, it should use that as global offset `goff` in the kernel (this is wrong in reference kernel as well, hence it gives the same wrong output).
4. In LOCAL == 1 kernel, in loading from source to local memory, only border threads should load more than one value. However, the conditions didn't take `WPTX/Y` parameters into account.