### PR TITLE
Add explicit header for std::stringstream

### DIFF
--- a/src/tuner_impl.cc
+++ b/src/tuner_impl.cc
@@ -38,7 +38,8 @@
 #include "internal/ml_models/linear_regression.h"
 #include "internal/ml_models/neural_network.h"
 
-#include <fstream> // std::ifstream, std::stringstream
+#include <sstream> // std::stringstream
+#include <fstream> // std::ifstream
 #include <iostream> // FILE
 #include <limits> // std::numeric_limits
 #include <algorithm> // std::min


### PR DESCRIPTION
When building with `Android clang version 11.0.5` this header need to be explicitly included and just including `fstream` is not enough.